### PR TITLE
Making Gennaro DKG's commitment extractable

### DIFF
--- a/pkg/mpc/sharing/interactive/dkg/gennaro/messages.go
+++ b/pkg/mpc/sharing/interactive/dkg/gennaro/messages.go
@@ -1,9 +1,9 @@
 package gennaro
 
 import (
-	"github.com/bronlabs/bron-crypto/pkg/proofs/sigma/compiler"
 	"github.com/bronlabs/bron-crypto/pkg/mpc/sharing/scheme/feldman"
 	pedersenVSS "github.com/bronlabs/bron-crypto/pkg/mpc/sharing/scheme/pedersen"
+	"github.com/bronlabs/bron-crypto/pkg/proofs/sigma/compiler"
 )
 
 // Round1Broadcast carries the dealer’s Pedersen VSS verification vector.


### PR DESCRIPTION
## Description
For a DKG one can use joint Feldman by all parties and then sum the result. This, however, introduces a bias since the rushing adversary sees honest Feldman coefficients. To avoid this, one should first send an extractable and equivocal commitment to the Feldman sharing and then reveal. 
Gennaro DKG is that, using the Pedersen commitments through the Pedersen VSS. 
As it stands currently, the commitments aren't fully extractable. This PR makes them extractable.

## Pull Request Checklist

### Scope
- [X] Summary and description are provided.
- [X] Changes are focused and scoped to one purpose.

### Testing (select all that apply)
- [ ] Unit tests
- [ ] Property tests
- [ ] Test vectors tests
- [ ] Benchmarks
- [ ] Not run (explain why)

### Documentation / Spec (if relevant)
- [ ] Updated/added docs or comments
- [ ] Spec updated or linked

### Notes
- [ ] Additional context is provided (if needed)
