### PR TITLE
Removing PublicKey from the constructors of Meta BLS shards

### DIFF
--- a/pkg/mpc/meta/signatures/bls/bls.go
+++ b/pkg/mpc/meta/signatures/bls/bls.go
@@ -191,19 +191,20 @@ func (s *Shard[PK, PKFE, SG, SGFE, E, S]) UnmarshalCBOR(data []byte) error {
 // In the short key variant, public keys are in G1 (shorter) and signatures are in G2 (longer).
 // This provides smaller public keys at the cost of larger signatures.
 //
+// The short/long variant is inferred from the type parameters: the public key
+// group's base field FE1 must be a prime field for the short variant.
+//
 // Parameters:
 //   - share: The party's Feldman share of the secret key
 //   - vector: The Feldman verification vector
-//   - accessStructure: The threshold access structure
+//   - mspMatrix: The MSP matrix induced from the access structure
 //
-// Returns an error if any parameter is nil, if the public key is not a short variant,
-// or if partial public key computation fails.
+// Returns an error if any parameter is nil or if base shard construction fails.
 func NewShortKeyShard[
 	P1 curves.PairingFriendlyPoint[P1, FE1, P2, FE2, E, S], FE1 algebra.PrimeFieldElement[FE1],
 	P2 curves.PairingFriendlyPoint[P2, FE2, P1, FE1, E, S], FE2 algebra.FieldElement[FE2],
 	E algebra.MultiplicativeGroupElement[E], S algebra.PrimeFieldElement[S],
 ](
-
 	share *feldman.Share[S],
 	vector *feldman.VerificationVector[P1, S],
 	mspMatrix *msp.MSP[S],
@@ -232,13 +233,15 @@ func NewShortKeyShard[
 // In the long key variant, public keys are in G2 (longer) and signatures are in G1 (shorter).
 // This provides smaller signatures at the cost of larger public keys.
 //
+// The short/long variant is inferred from the type parameters: the signature
+// group's base field FE1 must be a prime field for the long variant.
+//
 // Parameters:
 //   - share: The party's Feldman share of the secret key
 //   - vector: The Feldman verification vector
-//   - accessStructure: The threshold access structure
+//   - mspMatrix: The MSP matrix induced from the access structure
 //
-// Returns an error if any parameter is nil, if the public key is not a long variant,
-// or if partial public key computation fails.
+// Returns an error if any parameter is nil or if base shard construction fails.
 func NewLongKeyShard[
 	P1 curves.PairingFriendlyPoint[P1, FE1, P2, FE2, E, S], FE1 algebra.PrimeFieldElement[FE1],
 	P2 curves.PairingFriendlyPoint[P2, FE2, P1, FE1, E, S], FE2 algebra.FieldElement[FE2],

--- a/pkg/mpc/meta/signatures/bls/bls.go
+++ b/pkg/mpc/meta/signatures/bls/bls.go
@@ -80,6 +80,9 @@ func (spm *PublicMaterial[PK, PKFE, SG, SGFE, E, S]) UnmarshalCBOR(data []byte) 
 	if err != nil {
 		return errs.Wrap(err).WithMessage("failed to unmarshal public material from CBOR")
 	}
+	if dto == nil {
+		return ErrIsNil.WithMessage("unmarshalled public material DTO is nil")
+	}
 	if dto.Base == nil {
 		return ErrIsNil.WithMessage("missing required field in public material")
 	}
@@ -174,10 +177,12 @@ func (s *Shard[PK, PKFE, SG, SGFE, E, S]) UnmarshalCBOR(data []byte) error {
 	if err != nil {
 		return errs.Wrap(err).WithMessage("failed to unmarshal shard from CBOR")
 	}
+	if dto == nil {
+		return ErrIsNil.WithMessage("unmarshalled shard DTO is nil")
+	}
 	if dto.Base == nil {
 		return ErrIsNil.WithMessage("missing required field in shard")
 	}
-
 	s.BaseShard = *dto.Base
 	return nil
 }
@@ -188,37 +193,29 @@ func (s *Shard[PK, PKFE, SG, SGFE, E, S]) UnmarshalCBOR(data []byte) error {
 //
 // Parameters:
 //   - share: The party's Feldman share of the secret key
-//   - publicKey: The combined BLS public key (must be a short key variant)
 //   - vector: The Feldman verification vector
 //   - accessStructure: The threshold access structure
 //
 // Returns an error if any parameter is nil, if the public key is not a short variant,
 // or if partial public key computation fails.
 func NewShortKeyShard[
-	P1 curves.PairingFriendlyPoint[P1, FE1, P2, FE2, E, S], FE1 algebra.FieldElement[FE1],
+	P1 curves.PairingFriendlyPoint[P1, FE1, P2, FE2, E, S], FE1 algebra.PrimeFieldElement[FE1],
 	P2 curves.PairingFriendlyPoint[P2, FE2, P1, FE1, E, S], FE2 algebra.FieldElement[FE2],
 	E algebra.MultiplicativeGroupElement[E], S algebra.PrimeFieldElement[S],
 ](
 
 	share *feldman.Share[S],
-	publicKey *bls.PublicKey[P1, FE1, P2, FE2, E, S],
 	vector *feldman.VerificationVector[P1, S],
 	mspMatrix *msp.MSP[S],
 ) (*Shard[P1, FE1, P2, FE2, E, S], error) {
 	if share == nil {
 		return nil, ErrIsNil.WithMessage("share")
 	}
-	if publicKey == nil {
-		return nil, ErrIsNil.WithMessage("publicKey")
-	}
 	if mspMatrix == nil {
 		return nil, ErrIsNil.WithMessage("mspMatrix")
 	}
 	if vector == nil {
 		return nil, ErrIsNil.WithMessage("verification vector")
-	}
-	if !publicKey.IsShort() {
-		return nil, ErrInvalidArgument.WithMessage("public key is not a short key variant")
 	}
 
 	baseShard, err := mpc.NewBaseShard(share, vector, mspMatrix)
@@ -237,36 +234,28 @@ func NewShortKeyShard[
 //
 // Parameters:
 //   - share: The party's Feldman share of the secret key
-//   - publicKey: The combined BLS public key (must be a long key variant)
 //   - vector: The Feldman verification vector
 //   - accessStructure: The threshold access structure
 //
 // Returns an error if any parameter is nil, if the public key is not a long variant,
 // or if partial public key computation fails.
 func NewLongKeyShard[
-	P1 curves.PairingFriendlyPoint[P1, FE1, P2, FE2, E, S], FE1 algebra.FieldElement[FE1],
+	P1 curves.PairingFriendlyPoint[P1, FE1, P2, FE2, E, S], FE1 algebra.PrimeFieldElement[FE1],
 	P2 curves.PairingFriendlyPoint[P2, FE2, P1, FE1, E, S], FE2 algebra.FieldElement[FE2],
 	E algebra.MultiplicativeGroupElement[E], S algebra.PrimeFieldElement[S],
 ](
 	share *feldman.Share[S],
-	publicKey *bls.PublicKey[P2, FE2, P1, FE1, E, S],
 	vector *feldman.VerificationVector[P2, S],
 	mspMatrix *msp.MSP[S],
 ) (*Shard[P2, FE2, P1, FE1, E, S], error) {
 	if share == nil {
 		return nil, ErrIsNil.WithMessage("share")
 	}
-	if publicKey == nil {
-		return nil, ErrIsNil.WithMessage("publicKey")
-	}
 	if mspMatrix == nil {
 		return nil, ErrIsNil.WithMessage("mspMatrix")
 	}
 	if vector == nil {
 		return nil, ErrIsNil.WithMessage("verification vector")
-	}
-	if publicKey.IsShort() {
-		return nil, ErrInvalidArgument.WithMessage("public key is not a long key variant")
 	}
 
 	baseShard, err := mpc.NewBaseShard(share, vector, mspMatrix)

--- a/pkg/mpc/meta/signatures/bls/boldyreva02/keygen/keygen.go
+++ b/pkg/mpc/meta/signatures/bls/boldyreva02/keygen/keygen.go
@@ -6,14 +6,13 @@ import (
 	"github.com/bronlabs/bron-crypto/pkg/mpc"
 	mpcbls "github.com/bronlabs/bron-crypto/pkg/mpc/meta/signatures/bls"
 	"github.com/bronlabs/bron-crypto/pkg/mpc/meta/signatures/bls/boldyreva02"
-	"github.com/bronlabs/bron-crypto/pkg/signatures/bls"
 	"github.com/bronlabs/errs-go/errs"
 )
 
 var ErrIsNil = errs.New("input is nil")
 
 func NewShortKeyShard[
-	PK curves.PairingFriendlyPoint[PK, PKFE, SG, SGFE, E, S], PKFE algebra.FieldElement[PKFE],
+	PK curves.PairingFriendlyPoint[PK, PKFE, SG, SGFE, E, S], PKFE algebra.PrimeFieldElement[PKFE],
 	SG curves.PairingFriendlyPoint[SG, SGFE, PK, PKFE, E, S], SGFE algebra.FieldElement[SGFE],
 	E algebra.MultiplicativeGroupElement[E], S algebra.PrimeFieldElement[S],
 ](
@@ -22,11 +21,7 @@ func NewShortKeyShard[
 	if output == nil {
 		return nil, ErrIsNil.WithMessage("output is nil")
 	}
-	pk, err := bls.NewPublicKey(output.PublicKeyValue())
-	if err != nil {
-		return nil, errs.Wrap(err).WithMessage("failed to create BLS public key")
-	}
-	shard, err := mpcbls.NewShortKeyShard(output.Share(), pk, output.VerificationVector(), output.MSP())
+	shard, err := mpcbls.NewShortKeyShard(output.Share(), output.VerificationVector(), output.MSP())
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("failed to create tBLS short key shard")
 	}
@@ -35,7 +30,7 @@ func NewShortKeyShard[
 
 func NewLongKeyShard[
 	PK curves.PairingFriendlyPoint[PK, PKFE, SG, SGFE, E, S], PKFE algebra.FieldElement[PKFE],
-	SG curves.PairingFriendlyPoint[SG, SGFE, PK, PKFE, E, S], SGFE algebra.FieldElement[SGFE],
+	SG curves.PairingFriendlyPoint[SG, SGFE, PK, PKFE, E, S], SGFE algebra.PrimeFieldElement[SGFE],
 	E algebra.MultiplicativeGroupElement[E], S algebra.PrimeFieldElement[S],
 ](
 	output *mpc.BaseShard[PK, S],
@@ -43,11 +38,7 @@ func NewLongKeyShard[
 	if output == nil {
 		return nil, ErrIsNil.WithMessage("output is nil")
 	}
-	pk, err := bls.NewPublicKey(output.PublicKeyValue())
-	if err != nil {
-		return nil, errs.Wrap(err).WithMessage("failed to create BLS public key")
-	}
-	shard, err := mpcbls.NewLongKeyShard(output.Share(), pk, output.VerificationVector(), output.MSP())
+	shard, err := mpcbls.NewLongKeyShard(output.Share(), output.VerificationVector(), output.MSP())
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("failed to create tBLS long key shard")
 	}

--- a/pkg/mpc/meta/signatures/bls/boldyreva02/signing/signing_test.go
+++ b/pkg/mpc/meta/signatures/bls/boldyreva02/signing/signing_test.go
@@ -59,7 +59,7 @@ func TestBoldyrevaDKGAndSign(t *testing.T) {
 	}
 
 	// Run DKG using testutils
-	shards := tu.DoBoldyrevaDKG(t, parties, true) // true for short key
+	shards := tu.DoBoldyrevaDKGShort(t, parties)
 	require.Len(t, shards, total)
 
 	// Verify all shards have the same public key
@@ -186,7 +186,7 @@ func testThresholdSigningWithAlgorithm(t *testing.T, shortKey bool, rogueKeyAlg 
 			require.NoError(t, err)
 			parties[id] = p
 		}
-		shards := tu.DoBoldyrevaDKG(t, parties, true)
+		shards := tu.DoBoldyrevaDKGShort(t, parties)
 
 		// Select a quorum
 		quorumSet := hashset.NewComparable[sharing.ID]()
@@ -233,7 +233,7 @@ func testThresholdSigningWithAlgorithm(t *testing.T, shortKey bool, rogueKeyAlg 
 			require.NoError(t, err)
 			parties[id] = p
 		}
-		shards := tu.DoBoldyrevaDKG(t, parties, false)
+		shards := tu.DoBoldyrevaDKGLong(t, parties)
 
 		// Select a quorum
 		quorumSet := hashset.NewComparable[sharing.ID]()
@@ -307,7 +307,7 @@ func TestPartialSignatureVerification(t *testing.T) {
 	}
 
 	// Run DKG for long key
-	shards := tu.DoBoldyrevaDKG(t, parties, false) // false for long key
+	shards := tu.DoBoldyrevaDKGLong(t, parties)
 
 	// Create cosigners for all participants
 	cosigners := make([]*signing.Cosigner[*bls12381.PointG2, *bls12381.BaseFieldElementG2, *bls12381.PointG1, *bls12381.BaseFieldElementG1, *bls12381.GtElement, *bls12381.Scalar], 0, total)
@@ -392,7 +392,7 @@ func TestCosignerCreationErrors(t *testing.T) {
 		require.NoError(t, err)
 		parties[id] = p
 	}
-	shards := tu.DoBoldyrevaDKG(t, parties, true)
+	shards := tu.DoBoldyrevaDKGShort(t, parties)
 	shard := shards[sharing.ID(1)]
 
 	quorumSet := hashset.NewComparable[sharing.ID]()
@@ -464,7 +464,7 @@ func TestProducePartialSignatureErrors(t *testing.T) {
 		require.NoError(t, err)
 		parties[id] = p
 	}
-	shards := tu.DoBoldyrevaDKG(t, parties, true)
+	shards := tu.DoBoldyrevaDKGShort(t, parties)
 
 	shard := shards[sharing.ID(1)]
 
@@ -524,7 +524,7 @@ func TestAggregatorCreationErrors(t *testing.T) {
 		require.NoError(t, err)
 		parties[id] = p
 	}
-	shards := tu.DoBoldyrevaDKG(t, parties, true)
+	shards := tu.DoBoldyrevaDKGShort(t, parties)
 
 	shard, ok := shards[sharing.ID(1)]
 	require.True(t, ok)
@@ -569,7 +569,7 @@ func TestAggregationErrors(t *testing.T) {
 		require.NoError(t, err)
 		parties[id] = p
 	}
-	shards := tu.DoBoldyrevaDKG(t, parties, true)
+	shards := tu.DoBoldyrevaDKGShort(t, parties)
 
 	// Create cosigners and aggregator
 	quorumSet := hashset.NewComparable[sharing.ID]()
@@ -662,7 +662,7 @@ func TestDifferentQuorumConfigurations(t *testing.T) {
 				require.NoError(t, err)
 				parties[id] = p
 			}
-			shards := tu.DoBoldyrevaDKG(t, parties, true)
+			shards := tu.DoBoldyrevaDKGShort(t, parties)
 
 			// Create quorum
 			quorumSet := hashset.NewComparable[sharing.ID]()
@@ -723,7 +723,7 @@ func TestCosignerGetters(t *testing.T) {
 		require.NoError(t, err)
 		parties[id] = p
 	}
-	shards := tu.DoBoldyrevaDKG(t, parties, true)
+	shards := tu.DoBoldyrevaDKGShort(t, parties)
 
 	shard := shards[sharing.ID(1)]
 
@@ -807,7 +807,7 @@ func blsSetup(t *testing.T, thresh, total uint) (
 		require.NoError(t, err)
 		parties[id] = p
 	}
-	shards := tu.DoBoldyrevaDKG(t, parties, true)
+	shards := tu.DoBoldyrevaDKGShort(t, parties)
 
 	quorumSet := hashset.NewComparable[sharing.ID]()
 	for i := range thresh {

--- a/pkg/mpc/meta/signatures/bls/boldyreva02/testutils/testutils.go
+++ b/pkg/mpc/meta/signatures/bls/boldyreva02/testutils/testutils.go
@@ -24,34 +24,52 @@ import (
 type ShortKeyShard = boldyreva02.Shard[*bls12381.PointG1, *bls12381.BaseFieldElementG1, *bls12381.PointG2, *bls12381.BaseFieldElementG2, *bls12381.GtElement, *bls12381.Scalar]
 type LongKeyShard = boldyreva02.Shard[*bls12381.PointG2, *bls12381.BaseFieldElementG2, *bls12381.PointG1, *bls12381.BaseFieldElementG1, *bls12381.GtElement, *bls12381.Scalar]
 
-// DoBoldyrevaDKG runs the complete DKG process for Boldyreva02 BLS
-// It uses Gennaro DKG under the hood and converts the output to BLS shards.
-func DoBoldyrevaDKG[
-	PK curves.PairingFriendlyPoint[PK, PKFE, SG, SGFE, E, S], PKFE algebra.FieldElement[PKFE],
+// DoBoldyrevaDKGShort runs the complete DKG process for Boldyreva02 BLS in the
+// short key variant (public keys in G1, signatures in G2). It uses Gennaro DKG
+// under the hood and converts the output to short key BLS shards.
+func DoBoldyrevaDKGShort[
+	PK curves.PairingFriendlyPoint[PK, PKFE, SG, SGFE, E, S], PKFE algebra.PrimeFieldElement[PKFE],
 	SG curves.PairingFriendlyPoint[SG, SGFE, PK, PKFE, E, S], SGFE algebra.FieldElement[SGFE],
 	E algebra.MultiplicativeGroupElement[E], S algebra.PrimeFieldElement[S],
 ](
-	tb testing.TB, participants map[sharing.ID]*gennaro.Participant[PK, S], shortKey bool,
+	tb testing.TB, participants map[sharing.ID]*gennaro.Participant[PK, S],
 ) (
 	shards map[sharing.ID]*tbls.Shard[PK, PKFE, SG, SGFE, E, S],
 ) {
 	tb.Helper()
-	var err error
 
-	// Run Gennaro DKG
 	dkgOutputs := gentu.DoGennaroDKG(tb, participants)
 
-	// Convert DKG outputs to BLS shards
 	shards = make(map[sharing.ID]*tbls.Shard[PK, PKFE, SG, SGFE, E, S])
 	for id, output := range dkgOutputs {
-		var shard *tbls.Shard[PK, PKFE, SG, SGFE, E, S]
-		if shortKey {
-			shard, err = keygen.NewShortKeyShard(output)
-		} else {
-			shard, err = keygen.NewLongKeyShard(output)
-		}
+		shard, err := keygen.NewShortKeyShard(output)
 		require.NoError(tb, err)
+		shards[id] = shard
+	}
 
+	return shards
+}
+
+// DoBoldyrevaDKGLong runs the complete DKG process for Boldyreva02 BLS in the
+// long key variant (public keys in G2, signatures in G1). It uses Gennaro DKG
+// under the hood and converts the output to long key BLS shards.
+func DoBoldyrevaDKGLong[
+	PK curves.PairingFriendlyPoint[PK, PKFE, SG, SGFE, E, S], PKFE algebra.FieldElement[PKFE],
+	SG curves.PairingFriendlyPoint[SG, SGFE, PK, PKFE, E, S], SGFE algebra.PrimeFieldElement[SGFE],
+	E algebra.MultiplicativeGroupElement[E], S algebra.PrimeFieldElement[S],
+](
+	tb testing.TB, participants map[sharing.ID]*gennaro.Participant[PK, S],
+) (
+	shards map[sharing.ID]*tbls.Shard[PK, PKFE, SG, SGFE, E, S],
+) {
+	tb.Helper()
+
+	dkgOutputs := gentu.DoGennaroDKG(tb, participants)
+
+	shards = make(map[sharing.ID]*tbls.Shard[PK, PKFE, SG, SGFE, E, S])
+	for id, output := range dkgOutputs {
+		shard, err := keygen.NewLongKeyShard(output)
+		require.NoError(tb, err)
 		shards[id] = shard
 	}
 


### PR DESCRIPTION
## Description
We remove public key from the constructors of meta bls shards and instead infer whether the shard is short/long key from the type parameters

## Pull Request Checklist

### Scope
- [ ] Summary and description are provided.
- [ ] Changes are focused and scoped to one purpose.

### Testing (select all that apply)
- [ ] Unit tests
- [ ] Property tests
- [ ] Test vectors tests
- [ ] Benchmarks
- [ ] Not run (explain why)

### Documentation / Spec (if relevant)
- [ ] Updated/added docs or comments
- [ ] Spec updated or linked

### Notes
- [ ] Additional context is provided (if needed)
