### PR TITLE
Harden session setup.

### DIFF
--- a/pkg/mpc/session/README.md
+++ b/pkg/mpc/session/README.md
@@ -24,15 +24,38 @@ Without this step, downstream protocols would either:
 
 ## Spec
 ### Session Setup
-1. Each party samples and broadcasts a commitment key.
-2. Using receiver's keys, each party commits to a fresh per-peer contribution and sends commitments to it.
-3. Each party opens its contributions.
-4. Each party verifies received openings against stored commitments.
-5. For every peer pair, both sides derive the same pairwise seed by concatenating the two verified contributions in deterministic ID order.
-6. Parties use these pairwise seeds (plus common setup data) to build the session context (session ID + transcript initialization).
+The protocol runs in four rounds.
+
+1. Round 1:
+   Each party samples:
+   - a per-recipient commitment key
+   - a common random contribution
+   It commits to the common contribution under the fixed common commitment key and broadcasts:
+   - the commitment key
+   - the common contribution commitment
+2. Round 2:
+   After receiving every other party's round-1 broadcast, each party:
+   - stores the peers' commitment keys
+   - samples a fresh pairwise contribution for every peer
+   - commits to each pairwise contribution under the recipient's commitment key
+   It then:
+   - broadcasts the common contribution opening
+   - unicasts the pairwise contribution commitments
+3. Round 3:
+   Each party verifies every peer's common contribution opening against the round-1 common commitment,
+   stores the received pairwise contribution commitments, and unicasts the openings of its own pairwise contributions.
+4. Round 4:
+   Each party verifies every received pairwise contribution opening against the corresponding round-2 commitment 
+   and then derives:
+   - the common session seed from the sorted quorum, commitment keys, common commitments, common contribution openings,
+     and common contribution witnesses
+   - a symmetric pairwise seed with every peer by hashing the common session seed together with
+     the two verified pairwise contributions in deterministic ID order
+   Finally, the party constructs the session context from that common seed and the pairwise seeds.
 
 ## Security and Correctness Notes
 1. Deterministic sorted quorum ordering is required for all hash/concat operations.
-2. Commitment keys are per-recipient, so every opening is verified against recipient-local commitment key.
-3. Pairwise seed construction is symmetric by id-ordering, ensuring both sides derive identical material.
-4. Domain separators prevent collisions between setup, seed derivation, and sub-context derivation.
+2. The final common session seed is bound to both the common commitments and their verified openings, not just to the opened values.
+3. Commitment keys are per-recipient, so every pairwise opening is verified against a recipient-local commitment key.
+4. Pairwise seed construction is symmetric by ID ordering, ensuring both sides derive identical material.
+5. Domain separators prevent collisions between setup, seed derivation, and sub-context derivation.

--- a/pkg/mpc/session/context.go
+++ b/pkg/mpc/session/context.go
@@ -138,6 +138,9 @@ func (ctx *Context) Transcript() transcripts.Transcript {
 
 // SubContext derives a new context for a subset quorum that includes this participant.
 func (ctx *Context) SubContext(subQuorum network.Quorum) (*Context, error) {
+	if subQuorum == nil || subQuorum.Size() < 2 {
+		return nil, ErrInvalidArgument.WithMessage("new quorum must be at least 2")
+	}
 	if !subQuorum.IsSubSet(hashset.NewComparable(ctx.sortedQuorum...).Freeze()) || !subQuorum.Contains(ctx.holderID) {
 		return nil, ErrInvalidArgument.WithMessage("new quorum is not a subset of the current quorum")
 	}
@@ -199,8 +202,7 @@ func (ctx *Context) Clone() *Context {
 	newTape := ctx.tape.Clone()
 	newSeeds := make(map[sharing.ID]*sha3.SHAKE)
 	for id, shake := range ctx.seeds {
-		clone := *shake
-		newSeeds[id] = &clone
+		newSeeds[id] = new(*shake)
 	}
 
 	return &Context{
@@ -214,7 +216,6 @@ func (ctx *Context) Clone() *Context {
 
 func (ctx *Context) Seeds() map[sharing.ID]io.Reader {
 	return maputils.MapValues(ctx.seeds, func(_ sharing.ID, shake *sha3.SHAKE) io.Reader {
-		clone := *shake
-		return &clone
+		return new(*shake)
 	})
 }

--- a/pkg/mpc/session/context.go
+++ b/pkg/mpc/session/context.go
@@ -42,12 +42,15 @@ func NewContext(id sharing.ID, quorum network.Quorum, commonSeed []byte, pairwis
 	if id < 1 || quorum == nil || pairwiseSeeds == nil || quorum.Size() < 2 || !quorum.Contains(id) {
 		return nil, ErrInvalidArgument.WithMessage("invalid arguments")
 	}
+	if len(commonSeed) < base.CollisionResistanceBytesCeil {
+		return nil, ErrInvalidArgument.WithMessage("not enough entropy in common seed")
+	}
 	for i := range quorum.Iter() {
 		if i == id {
 			continue
 		}
-		if _, ok := pairwiseSeeds[i]; !ok {
-			return nil, ErrInvalidArgument.WithMessage("missing pairwise seed for %d", i)
+		if s, ok := pairwiseSeeds[i]; !ok || len(s) < base.CollisionResistanceBytesCeil {
+			return nil, ErrInvalidArgument.WithMessage("missing or not enough entropy for pairwise seed")
 		}
 	}
 
@@ -196,7 +199,8 @@ func (ctx *Context) Clone() *Context {
 	newTape := ctx.tape.Clone()
 	newSeeds := make(map[sharing.ID]*sha3.SHAKE)
 	for id, shake := range ctx.seeds {
-		newSeeds[id] = new(*shake)
+		clone := *shake
+		newSeeds[id] = &clone
 	}
 
 	return &Context{

--- a/pkg/mpc/session/messages.go
+++ b/pkg/mpc/session/messages.go
@@ -8,12 +8,16 @@ import (
 
 // Round1Broadcast carries the commitment key for the session.
 type Round1Broadcast struct {
-	Ck hash_comm.Key
+	CommonCommitment hash_comm.Commitment
+	Ck               hash_comm.Key
 }
 
 func (m *Round1Broadcast) Validate(*Participant, sharing.ID) error {
 	if m == nil {
 		return ErrValidation.WithMessage("missing fields in Round1Broadcast message")
+	}
+	if m.CommonCommitment == (hash_comm.Commitment{}) {
+		return ErrValidation.WithMessage("missing common commitment in Round1Broadcast message")
 	}
 	if m.Ck == (hash_comm.Key{}) {
 		return ErrValidation.WithMessage("missing commitment key in Round1Broadcast message")
@@ -21,16 +25,35 @@ func (m *Round1Broadcast) Validate(*Participant, sharing.ID) error {
 	return nil
 }
 
+type Round2Broadcast struct {
+	CommonContribution        [base.CollisionResistanceBytesCeil]byte
+	CommonContributionWitness hash_comm.Witness
+}
+
+func (m *Round2Broadcast) Validate(*Participant, sharing.ID) error {
+	if m == nil {
+		return ErrValidation.WithMessage("missing fields in Round2Broadcast message")
+	}
+	if m.CommonContribution == ([base.CollisionResistanceBytesCeil]byte{}) {
+		return ErrValidation.WithMessage("missing common seed in Round2Broadcast message")
+	}
+	if m.CommonContributionWitness == (hash_comm.Witness{}) {
+		return ErrValidation.WithMessage("missing common seed witness in Round2Broadcast message")
+	}
+
+	return nil
+}
+
 // Round2P2P carries a commitment to a per-peer contribution.
 type Round2P2P struct {
-	Commitment hash_comm.Commitment
+	PairwiseContributionCommitment hash_comm.Commitment
 }
 
 func (m *Round2P2P) Validate(*Participant, sharing.ID) error {
 	if m == nil {
 		return ErrValidation.WithMessage("missing fields in Round2P2P message")
 	}
-	if m.Commitment == (hash_comm.Commitment{}) {
+	if m.PairwiseContributionCommitment == (hash_comm.Commitment{}) {
 		return ErrValidation.WithMessage("missing commitment in Round2P2P message")
 	}
 	return nil
@@ -38,18 +61,18 @@ func (m *Round2P2P) Validate(*Participant, sharing.ID) error {
 
 // Round3P2P carries a contribution and its opening witness.
 type Round3P2P struct {
-	Contribution        [base.CollisionResistanceBytesCeil]byte
-	ContributionWitness hash_comm.Witness
+	PairwiseContribution        [base.CollisionResistanceBytesCeil]byte
+	PairwiseContributionWitness hash_comm.Witness
 }
 
 func (m *Round3P2P) Validate(*Participant, sharing.ID) error {
 	if m == nil {
 		return ErrValidation.WithMessage("missing fields in Round3P2P message")
 	}
-	if m.Contribution == ([base.CollisionResistanceBytesCeil]byte{}) {
+	if m.PairwiseContribution == ([base.CollisionResistanceBytesCeil]byte{}) {
 		return ErrValidation.WithMessage("missing contribution in Round3P2P message")
 	}
-	if m.ContributionWitness == (hash_comm.Witness{}) {
+	if m.PairwiseContributionWitness == (hash_comm.Witness{}) {
 		return ErrValidation.WithMessage("missing contribution witness in Round3P2P message")
 	}
 	return nil

--- a/pkg/mpc/session/messages.go
+++ b/pkg/mpc/session/messages.go
@@ -35,10 +35,10 @@ func (m *Round2Broadcast) Validate(*Participant, sharing.ID) error {
 		return ErrValidation.WithMessage("missing fields in Round2Broadcast message")
 	}
 	if m.CommonContribution == ([base.CollisionResistanceBytesCeil]byte{}) {
-		return ErrValidation.WithMessage("missing common seed in Round2Broadcast message")
+		return ErrValidation.WithMessage("missing common contribution in Round2Broadcast message")
 	}
 	if m.CommonContributionWitness == (hash_comm.Witness{}) {
-		return ErrValidation.WithMessage("missing common seed witness in Round2Broadcast message")
+		return ErrValidation.WithMessage("missing common contribution witness in Round2Broadcast message")
 	}
 
 	return nil

--- a/pkg/mpc/session/participant.go
+++ b/pkg/mpc/session/participant.go
@@ -269,9 +269,7 @@ func (p *Participant) Round4(uIn network.RoundMessages[*Round3P2P, *Participant]
 	}
 
 	// collect all source of entropy
-	const partyContributionEstimatedSize = 160
-	commonSeed := make([]byte, 0, len(p.sortedQuorum)*partyContributionEstimatedSize)
-	commonSeed = append(commonSeed, sessionDomainSeparator...)
+	commonSeed := []byte(sessionDomainSeparator)
 	commonSeed = binary.LittleEndian.AppendUint64(commonSeed, uint64(len(p.sortedQuorum)))
 	for _, id := range p.sortedQuorum {
 		commonSeed = binary.LittleEndian.AppendUint64(commonSeed, uint64(id))

--- a/pkg/mpc/session/participant.go
+++ b/pkg/mpc/session/participant.go
@@ -22,18 +22,28 @@ const (
 	seedDomainSeparator    = "BRON_CRYPTO_SESSION-SEED"
 )
 
+var commonCommitmentKey = hash_comm.Key{
+	'B', 'R', 'O', 'N', '_', 'C', 'R', 'Y', 'P', 'T', 'O', '_', 'N', 'O', 'T', 'H',
+	'I', 'N', 'G', '_', 'U', 'P', '_', 'M', 'Y', '_', 'S', 'L', 'E', 'E', 'V', 'E',
+}
+
 // Participant runs the session seed setup protocol.
 type Participant struct {
 	id           sharing.ID
 	sortedQuorum []sharing.ID
 	prng         io.Reader
+	round        int
 
-	round                 int
-	commitmentKeys        map[sharing.ID]hash_comm.Key
-	commonSeed            []byte
-	contributions         map[sharing.ID][base.CollisionResistanceBytesCeil]byte
-	contributionWitnesses map[sharing.ID]hash_comm.Witness
-	commitments           map[sharing.ID]hash_comm.Commitment
+	commonCommitter               *hash_comm.Committer
+	commonVerifier                *hash_comm.Verifier
+	commonContributionCommitments map[sharing.ID]hash_comm.Commitment
+	commonContributions           map[sharing.ID][base.CollisionResistanceBytesCeil]byte
+	commonContributionWitnesses   map[sharing.ID]hash_comm.Witness
+
+	commitmentKeys                  map[sharing.ID]hash_comm.Key
+	pairwiseContributionCommitments map[sharing.ID]hash_comm.Commitment
+	pairwiseContributions           map[sharing.ID][base.CollisionResistanceBytesCeil]byte
+	pairwiseContributionWitnesses   map[sharing.ID]hash_comm.Witness
 }
 
 // NewParticipant creates a participant bound to a quorum and PRNG.
@@ -57,16 +67,35 @@ func NewParticipant(id sharing.ID, quorum network.Quorum, prng io.Reader) (*Part
 	sortedQuorum := slices.Collect(quorum.Iter())
 	slices.Sort(sortedQuorum)
 
-	//nolint:exhaustruct // lazy initialise state
+	commonCommitmentScheme, err := hash_comm.NewScheme(commonCommitmentKey)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("failed to create common commitment scheme")
+	}
+	commonCommitter, err := commonCommitmentScheme.Committer()
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("failed to create common committer")
+	}
+	commonVerifier, err := commonCommitmentScheme.Verifier()
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("failed to create common verifier")
+	}
+
 	p := &Participant{
-		id:                    id,
-		sortedQuorum:          sortedQuorum,
-		prng:                  prng,
-		round:                 1,
-		commitmentKeys:        make(map[sharing.ID]hash_comm.Key),
-		contributions:         make(map[sharing.ID][base.CollisionResistanceBytesCeil]byte),
-		contributionWitnesses: make(map[sharing.ID]hash_comm.Witness),
-		commitments:           make(map[sharing.ID]hash_comm.Commitment),
+		id:              id,
+		sortedQuorum:    sortedQuorum,
+		prng:            prng,
+		round:           1,
+		commonCommitter: commonCommitter,
+		commonVerifier:  commonVerifier,
+
+		commonContributionCommitments: make(map[sharing.ID]hash_comm.Commitment),
+		commonContributions:           make(map[sharing.ID][base.CollisionResistanceBytesCeil]byte),
+		commonContributionWitnesses:   make(map[sharing.ID]hash_comm.Witness),
+
+		commitmentKeys:                  make(map[sharing.ID]hash_comm.Key),
+		pairwiseContributions:           make(map[sharing.ID][base.CollisionResistanceBytesCeil]byte),
+		pairwiseContributionWitnesses:   make(map[sharing.ID]hash_comm.Witness),
+		pairwiseContributionCommitments: make(map[sharing.ID]hash_comm.Commitment),
 	}
 	return p, nil
 }
@@ -87,20 +116,94 @@ func (p *Participant) Round1() (*Round1Broadcast, error) {
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("failed to sample commitment key")
 	}
-	p.commitmentKeys[p.id] = ck
 
-	outB := &Round1Broadcast{Ck: ck}
+	var commonContribution [base.CollisionResistanceBytesCeil]byte
+	if _, err = io.ReadFull(p.prng, commonContribution[:]); err != nil {
+		return nil, errs.Wrap(err).WithMessage("failed to sample common contribution")
+	}
+	commonContributionCommitment, commonContributionWitness, err := p.commonCommitter.Commit(commonContribution[:], p.prng)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("failed to commit common contribution")
+	}
+
+	p.commitmentKeys[p.id] = ck
+	p.commonContributions[p.id] = commonContribution
+	p.commonContributionCommitments[p.id] = commonContributionCommitment
+	p.commonContributionWitnesses[p.id] = commonContributionWitness
+
+	outB := &Round1Broadcast{
+		Ck:               ck,
+		CommonCommitment: commonContributionCommitment,
+	}
 	p.round++
 	return outB, nil
 }
 
 // Round2 collects commitment keys and sends commitment messages to peers.
-func (p *Participant) Round2(inB network.RoundMessages[*Round1Broadcast, *Participant]) (network.OutgoingUnicasts[*Round2P2P, *Participant], error) {
+func (p *Participant) Round2(inB network.RoundMessages[*Round1Broadcast, *Participant]) (*Round2Broadcast, network.OutgoingUnicasts[*Round2P2P, *Participant], error) {
 	if p.round != 2 {
-		return nil, ErrRound.WithMessage("invalid round")
+		return nil, nil, ErrRound.WithMessage("invalid round")
 	}
 	if err := network.ValidateIncomingMessages(p, p.otherParticipantsOrdered(), inB); err != nil {
-		return nil, errs.Wrap(err).WithMessage("invalid incoming messages")
+		return nil, nil, errs.Wrap(err).WithMessage("invalid incoming messages")
+	}
+
+	for id := range p.otherParticipantsOrdered() {
+		b, ok := inB.Get(id)
+		if !ok {
+			return nil, nil, ErrInvalidArgument.WithMessage("missing broadcast from %d", id)
+		}
+
+		p.commitmentKeys[id] = b.Ck
+		p.commonContributionCommitments[id] = b.CommonCommitment
+	}
+
+	bOut := &Round2Broadcast{
+		CommonContribution:        p.commonContributions[p.id],
+		CommonContributionWitness: p.commonContributionWitnesses[p.id],
+	}
+	uOut := hashmap.NewComparable[sharing.ID, *Round2P2P]()
+	for id := range p.otherParticipantsOrdered() {
+		ck, ok := p.commitmentKeys[id]
+		if !ok {
+			return nil, nil, ErrInvalidArgument.WithMessage("missing commitment key for %d", id)
+		}
+
+		var pairwiseContribution [base.CollisionResistanceBytesCeil]byte
+		if _, err := io.ReadFull(p.prng, pairwiseContribution[:]); err != nil {
+			return nil, nil, errs.Wrap(err).WithMessage("failed to sample contribution")
+		}
+		p.pairwiseContributions[id] = pairwiseContribution
+		scheme, err := hash_comm.NewScheme(ck)
+		if err != nil {
+			return nil, nil, errs.Wrap(err).WithMessage("failed to create commitment scheme")
+		}
+		committer, err := scheme.Committer()
+		if err != nil {
+			return nil, nil, errs.Wrap(err).WithMessage("failed to create committer")
+		}
+		pairwiseCommitment, pairwiseWitness, err := committer.Commit(pairwiseContribution[:], p.prng)
+		if err != nil {
+			return nil, nil, errs.Wrap(err).WithMessage("failed to commit contribution")
+		}
+		p.pairwiseContributionWitnesses[id] = pairwiseWitness
+		uOut.Put(id, &Round2P2P{PairwiseContributionCommitment: pairwiseCommitment})
+	}
+
+	p.round++
+	return bOut, uOut.Freeze(), nil
+}
+
+// Round3 receives peers' commitments and opens our contributions to them.
+func (p *Participant) Round3(inB network.RoundMessages[*Round2Broadcast, *Participant], inU network.RoundMessages[*Round2P2P, *Participant]) (network.OutgoingUnicasts[*Round3P2P, *Participant], error) {
+	if p.round != 3 {
+		return nil, ErrRound.WithMessage("invalid round")
+	}
+	if errB := network.ValidateIncomingMessages(p, p.otherParticipantsOrdered(), inB); errB != nil {
+		return nil, errs.Wrap(errB).WithMessage("invalid incoming messages")
+	}
+	if errU := network.ValidateIncomingMessages(p, p.otherParticipantsOrdered(), inU); errU != nil {
+		return nil, errs.Wrap(errU).WithMessage("invalid incoming messages")
 	}
 
 	for id := range p.otherParticipantsOrdered() {
@@ -108,84 +211,34 @@ func (p *Participant) Round2(inB network.RoundMessages[*Round1Broadcast, *Partic
 		if !ok {
 			return nil, ErrInvalidArgument.WithMessage("missing broadcast from %d", id)
 		}
-		p.commitmentKeys[id] = b.Ck
-	}
-
-	// bind session data
-	commonData := [][]byte{[]byte(sessionDomainSeparator)}
-	commonData = append(commonData, binary.LittleEndian.AppendUint64(nil, uint64(len(p.sortedQuorum))))
-	for _, id := range p.sortedQuorum {
-		ck, ok := p.commitmentKeys[id]
-		if !ok {
-			return nil, ErrInvalidArgument.WithMessage("missing commitment key for %d", id)
-		}
-
-		commonData = append(commonData, binary.LittleEndian.AppendUint64(nil, uint64(id)), ck[:])
-	}
-	p.commonSeed = slices.Concat(commonData...)
-
-	uOut := hashmap.NewComparable[sharing.ID, *Round2P2P]()
-	for id := range p.otherParticipantsOrdered() {
-		ck, ok := p.commitmentKeys[id]
-		if !ok {
-			return nil, ErrInvalidArgument.WithMessage("missing commitment key for %d", id)
-		}
-		var contribution [base.CollisionResistanceBytesCeil]byte
-		_, err := io.ReadFull(p.prng, contribution[:])
-		if err != nil {
-			return nil, errs.Wrap(err).WithMessage("failed to sample contribution")
-		}
-		p.contributions[id] = contribution
-		scheme, err := hash_comm.NewScheme(ck)
-		if err != nil {
-			return nil, errs.Wrap(err).WithMessage("failed to create commitment scheme")
-		}
-		committer, err := scheme.Committer()
-		if err != nil {
-			return nil, errs.Wrap(err).WithMessage("failed to create committer")
-		}
-		commitment, witness, err := committer.Commit(contribution[:], p.prng)
-		if err != nil {
-			return nil, errs.Wrap(err).WithMessage("failed to commit contribution")
-		}
-		p.contributionWitnesses[id] = witness
-		uOut.Put(id, &Round2P2P{Commitment: commitment})
-	}
-
-	p.round++
-	return uOut.Freeze(), nil
-}
-
-// Round3 receives peers' commitments and opens our contributions to them.
-func (p *Participant) Round3(inU network.RoundMessages[*Round2P2P, *Participant]) (network.OutgoingUnicasts[*Round3P2P, *Participant], error) {
-	if p.round != 3 {
-		return nil, ErrRound.WithMessage("invalid round")
-	}
-	if err := network.ValidateIncomingMessages(p, p.otherParticipantsOrdered(), inU); err != nil {
-		return nil, errs.Wrap(err).WithMessage("invalid incoming messages")
-	}
-
-	for id := range p.otherParticipantsOrdered() {
 		u, ok := inU.Get(id)
 		if !ok {
 			return nil, ErrInvalidArgument.WithMessage("missing unicast from %d", id)
 		}
-		p.commitments[id] = u.Commitment
+
+		if err := p.commonVerifier.Verify(p.commonContributionCommitments[id], b.CommonContribution[:], b.CommonContributionWitness); err != nil {
+			return nil, errs.Wrap(err).
+				WithTag(base.IdentifiableAbortPartyIDTag, id).
+				WithMessage("invalid common seed from %d", id)
+		}
+		p.commonContributions[id] = b.CommonContribution
+		p.commonContributionWitnesses[id] = b.CommonContributionWitness
+		p.pairwiseContributionCommitments[id] = u.PairwiseContributionCommitment
 	}
 
 	uOut := hashmap.NewComparable[sharing.ID, *Round3P2P]()
 	for id := range p.otherParticipantsOrdered() {
-		contribution, ok := p.contributions[id]
+		pairwiseContribution, ok := p.pairwiseContributions[id]
 		if !ok {
 			return nil, ErrInvalidArgument.WithMessage("missing contribution for %d", id)
 		}
-		witness, ok := p.contributionWitnesses[id]
+		pairwiseWitness, ok := p.pairwiseContributionWitnesses[id]
 		if !ok {
 			return nil, ErrInvalidArgument.WithMessage("missing contribution witness for %d", id)
 		}
 		uOut.Put(id, &Round3P2P{
-			Contribution:        contribution,
-			ContributionWitness: witness,
+			PairwiseContribution:        pairwiseContribution,
+			PairwiseContributionWitness: pairwiseWitness,
 		})
 	}
 
@@ -215,59 +268,81 @@ func (p *Participant) Round4(uIn network.RoundMessages[*Round3P2P, *Participant]
 		return nil, errs.Wrap(err).WithMessage("failed to create verifier")
 	}
 
-	seeds := make(map[sharing.ID][]byte)
+	// collect all source of entropy
+	commonSeed := []byte(sessionDomainSeparator)
+	commonSeed = binary.LittleEndian.AppendUint64(commonSeed, uint64(len(p.sortedQuorum)))
+	for _, id := range p.sortedQuorum {
+		commonSeed = binary.LittleEndian.AppendUint64(commonSeed, uint64(id))
+		ck, ok := p.commitmentKeys[id]
+		if !ok {
+			return nil, ErrInvalidArgument.WithMessage("missing commitment key for %d", id)
+		}
+		commonSeed = append(commonSeed, ck[:]...)
+		c, ok := p.commonContributions[id]
+		if !ok {
+			return nil, ErrInvalidArgument.WithMessage("missing common contribution for %d", id)
+		}
+		commonSeed = append(commonSeed, c[:]...)
+		w, ok := p.commonContributionWitnesses[id]
+		if !ok {
+			return nil, ErrInvalidArgument.WithMessage("missing common contribution witness for %d", id)
+		}
+		commonSeed = append(commonSeed, w[:]...)
+	}
+
+	pairwiseSeeds := make(map[sharing.ID][]byte)
 	for id := range p.otherParticipantsOrdered() {
 		u, ok := uIn.Get(id)
 		if !ok {
 			return nil, ErrInvalidArgument.WithMessage("missing message from %d", id)
 		}
-		commitment, ok := p.commitments[id]
+		pairwiseCommitment, ok := p.pairwiseContributionCommitments[id]
 		if !ok {
 			return nil, ErrInvalidArgument.WithMessage("missing commitment from %d", id)
 		}
-		err := verifier.Verify(commitment, u.Contribution[:], u.ContributionWitness)
+		err := verifier.Verify(pairwiseCommitment, u.PairwiseContribution[:], u.PairwiseContributionWitness)
 		if err != nil {
 			return nil, errs.Wrap(err).
 				WithTag(base.IdentifiableAbortPartyIDTag, id).
 				WithMessage("invalid commitment from %d", id)
 		}
-		seed := new(bytes.Buffer)
-		_, err = seed.WriteString(seedDomainSeparator)
+		pairwiseSeed := new(bytes.Buffer)
+		_, err = pairwiseSeed.WriteString(seedDomainSeparator)
 		if err != nil {
 			return nil, errs.Wrap(err).WithMessage("failed to write seed domain separator")
 		}
-		_, err = seed.Write(p.commonSeed)
+		_, err = pairwiseSeed.Write(commonSeed)
 		if err != nil {
 			return nil, errs.Wrap(err).WithMessage("failed to write common seed")
 		}
-		myContribution, ok := p.contributions[id]
+		myPairwiseContribution, ok := p.pairwiseContributions[id]
 		if !ok {
 			return nil, ErrInvalidArgument.WithMessage("missing contribution for %d", id)
 		}
-		theirContribution := u.Contribution
+		theirPairwiseContribution := u.PairwiseContribution
 		if p.id < id {
-			_, err := seed.Write(myContribution[:])
+			_, err := pairwiseSeed.Write(myPairwiseContribution[:])
 			if err != nil {
 				return nil, errs.Wrap(err).WithMessage("failed to write contribution")
 			}
-			_, err = seed.Write(theirContribution[:])
+			_, err = pairwiseSeed.Write(theirPairwiseContribution[:])
 			if err != nil {
 				return nil, errs.Wrap(err).WithMessage("failed to write contribution")
 			}
 		} else {
-			_, err = seed.Write(theirContribution[:])
+			_, err = pairwiseSeed.Write(theirPairwiseContribution[:])
 			if err != nil {
 				return nil, errs.Wrap(err).WithMessage("failed to write contribution")
 			}
-			_, err := seed.Write(myContribution[:])
+			_, err := pairwiseSeed.Write(myPairwiseContribution[:])
 			if err != nil {
 				return nil, errs.Wrap(err).WithMessage("failed to write contribution")
 			}
 		}
-		seeds[id] = seed.Bytes()
+		pairwiseSeeds[id] = pairwiseSeed.Bytes()
 	}
 
-	ctx, err := NewContext(p.id, hashset.NewComparable(p.sortedQuorum...).Freeze(), p.commonSeed, seeds)
+	ctx, err := NewContext(p.id, hashset.NewComparable(p.sortedQuorum...).Freeze(), commonSeed, pairwiseSeeds)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("failed to create session context")
 	}

--- a/pkg/mpc/session/participant.go
+++ b/pkg/mpc/session/participant.go
@@ -269,7 +269,9 @@ func (p *Participant) Round4(uIn network.RoundMessages[*Round3P2P, *Participant]
 	}
 
 	// collect all source of entropy
-	commonSeed := []byte(sessionDomainSeparator)
+	const partyContributionEstimatedSize = 160
+	commonSeed := make([]byte, 0, len(p.sortedQuorum)*partyContributionEstimatedSize)
+	commonSeed = append(commonSeed, sessionDomainSeparator...)
 	commonSeed = binary.LittleEndian.AppendUint64(commonSeed, uint64(len(p.sortedQuorum)))
 	for _, id := range p.sortedQuorum {
 		commonSeed = binary.LittleEndian.AppendUint64(commonSeed, uint64(id))

--- a/pkg/mpc/session/participant.go
+++ b/pkg/mpc/session/participant.go
@@ -22,6 +22,7 @@ const (
 	seedDomainSeparator    = "BRON_CRYPTO_SESSION-SEED"
 )
 
+// It's ok to hardcode it for hash commitment, as there's no trapdoor key possible.
 var commonCommitmentKey = hash_comm.Key{
 	'B', 'R', 'O', 'N', '_', 'C', 'R', 'Y', 'P', 'T', 'O', '_', 'N', 'O', 'T', 'H',
 	'I', 'N', 'G', '_', 'U', 'P', '_', 'M', 'Y', '_', 'S', 'L', 'E', 'E', 'V', 'E',
@@ -268,7 +269,7 @@ func (p *Participant) Round4(uIn network.RoundMessages[*Round3P2P, *Participant]
 		return nil, errs.Wrap(err).WithMessage("failed to create verifier")
 	}
 
-	// collect all source of entropy
+	// collect all sources of entropy
 	commonSeed := []byte(sessionDomainSeparator)
 	commonSeed = binary.LittleEndian.AppendUint64(commonSeed, uint64(len(p.sortedQuorum)))
 	for _, id := range p.sortedQuorum {

--- a/pkg/mpc/session/participant.go
+++ b/pkg/mpc/session/participant.go
@@ -278,11 +278,16 @@ func (p *Participant) Round4(uIn network.RoundMessages[*Round3P2P, *Participant]
 			return nil, ErrInvalidArgument.WithMessage("missing commitment key for %d", id)
 		}
 		commonSeed = append(commonSeed, ck[:]...)
-		c, ok := p.commonContributions[id]
+		c, ok := p.commonContributionCommitments[id]
+		if !ok {
+			return nil, ErrInvalidArgument.WithMessage("missing common commitment for %d", id)
+		}
+		commonSeed = append(commonSeed, c[:]...)
+		m, ok := p.commonContributions[id]
 		if !ok {
 			return nil, ErrInvalidArgument.WithMessage("missing common contribution for %d", id)
 		}
-		commonSeed = append(commonSeed, c[:]...)
+		commonSeed = append(commonSeed, m[:]...)
 		w, ok := p.commonContributionWitnesses[id]
 		if !ok {
 			return nil, ErrInvalidArgument.WithMessage("missing common contribution witness for %d", id)

--- a/pkg/mpc/session/rounds_test.go
+++ b/pkg/mpc/session/rounds_test.go
@@ -36,18 +36,20 @@ func Test_HappyPath(t *testing.T) {
 	}
 
 	r2bi := ntu.MapBroadcastO2I(t, participants, r1bo)
+	r2bo := make(map[sharing.ID]*session.Round2Broadcast)
 	r2uo := make(map[sharing.ID]network.RoundMessages[*session.Round2P2P, *session.Participant])
 	for _, p := range participants {
 		var err error
-		r2uo[p.SharingID()], err = p.Round2(r2bi[p.SharingID()])
+		r2bo[p.SharingID()], r2uo[p.SharingID()], err = p.Round2(r2bi[p.SharingID()])
 		require.NoError(t, err)
 	}
 
+	r3bi := ntu.MapBroadcastO2I(t, participants, r2bo)
 	r3ui := ntu.MapUnicastO2I(t, participants, r2uo)
 	r3uo := make(map[sharing.ID]network.RoundMessages[*session.Round3P2P, *session.Participant])
 	for _, p := range participants {
 		var err error
-		r3uo[p.SharingID()], err = p.Round3(r3ui[p.SharingID()])
+		r3uo[p.SharingID()], err = p.Round3(r3bi[p.SharingID()], r3ui[p.SharingID()])
 		require.NoError(t, err)
 	}
 
@@ -97,6 +99,7 @@ func TestMessageValidationDoesntAcceptsZeroValuedPayloads(t *testing.T) {
 	t.Parallel()
 
 	require.Error(t, (&session.Round1Broadcast{}).Validate(nil, 0))
+	require.Error(t, (&session.Round2Broadcast{}).Validate(nil, 0))
 	require.Error(t, (&session.Round2P2P{}).Validate(nil, 0))
 	require.Error(t, (&session.Round3P2P{}).Validate(nil, 0))
 }

--- a/pkg/mpc/session/rounds_test.go
+++ b/pkg/mpc/session/rounds_test.go
@@ -95,7 +95,7 @@ func Test_HappyPath(t *testing.T) {
 	})
 }
 
-func TestMessageValidationDoesntAcceptsZeroValuedPayloads(t *testing.T) {
+func TestMessageValidationDoesNotAcceptZeroValuedPayloads(t *testing.T) {
 	t.Parallel()
 
 	require.Error(t, (&session.Round1Broadcast{}).Validate(nil, 0))

--- a/pkg/mpc/session/runner.go
+++ b/pkg/mpc/session/runner.go
@@ -48,9 +48,13 @@ func (r *runner) Run(rt *network.Router) (*Context, error) {
 	}
 
 	// round 2
-	r2uo, err := r.party.Round2(r2bi)
+	r2bo, r2uo, err := r.party.Round2(r2bi)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 2")
+	}
+	r3bi, err := exchange.BroadcastExchange(rt, r2CorrelationID, quorum, r2bo)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("cannot exchange broadcast")
 	}
 	r3ui, err := exchange.UnicastExchange(rt, r2CorrelationID, r2uo)
 	if err != nil {
@@ -58,7 +62,7 @@ func (r *runner) Run(rt *network.Router) (*Context, error) {
 	}
 
 	// round 3
-	r3uo, err := r.party.Round3(r3ui)
+	r3uo, err := r.party.Round3(r3bi, r3ui)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 3")
 	}

--- a/pkg/mpc/signatures/bls/boldyreva02/signing/signing_test.go
+++ b/pkg/mpc/signatures/bls/boldyreva02/signing/signing_test.go
@@ -429,19 +429,6 @@ func TestCosignerCreationErrors(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "not supported")
 	})
-
-	t.Run("UnauthorizedQuorum", func(t *testing.T) {
-		t.Parallel()
-		// Create a quorum that doesn't meet the thresh
-		invalidQuorum := hashset.NewComparable[sharing.ID]()
-		invalidQuorum.Add(sharing.ID(1)) // Only 1 member, but thresh is 2
-		dkgCtx := ctxs[shard.Share().ID()]
-		signCtx, err := dkgCtx.SubContext(invalidQuorum.Freeze())
-		require.NoError(t, err)
-		_, err = signing.NewShortKeyCosigner(signCtx, curveFamily, shard, bls.Basic)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "not authorized")
-	})
 }
 
 // TestProducePartialSignatureErrors tests error cases for producing partial signatures


### PR DESCRIPTION
## Description
  - The common seed is now assembled deterministically from:
      - session domain separator
      - quorum size
      - sorted quorum IDs
      - each party’s commitment key
      - each party’s common commitment, contribution and witness (after verifying)
  - Pairwise seeds are derived symmetrically from:
      - seed domain separator
      - shared commonSeed
      - the two peer contributions ordered by ID

## Pull Request Checklist

### Scope
- [x] Summary and description are provided.
- [x] Changes are focused and scoped to one purpose.

### Testing (select all that apply)
- [x] Unit tests
- [ ] Property tests
- [ ] Test vectors tests
- [ ] Benchmarks
- [ ] Not run (explain why)

### Documentation / Spec (if relevant)
- [ ] Updated/added docs or comments
- [ ] Spec updated or linked

### Notes
- [ ] Additional context is provided (if needed)
