### PR TITLE
Implement brute-force maximal unqualified set iterators for hierarchical and threshold-gate access structures.

### DIFF
--- a/pkg/mpc/sharing/accessstructures/boolexpr/README.md
+++ b/pkg/mpc/sharing/accessstructures/boolexpr/README.md
@@ -35,6 +35,10 @@ ac, _ := boolexpr.NewThresholdGateAccessStructure(
 qualified := ac.IsQualified(1, 2, 5, 6)
 ```
 
+`MaximalUnqualifiedSetsIter` is also available. Its current implementation is
+brute-force and intended only for small access structures, and it requires
+shareholder IDs to lie in the range `1..64`.
+
 ## MSP Induction
 
 `InducedMSP` converts a threshold-gate tree into a monotone span programme following Algorithm 1 of [[1]][1]:

--- a/pkg/mpc/sharing/accessstructures/boolexpr/boolexpr.go
+++ b/pkg/mpc/sharing/accessstructures/boolexpr/boolexpr.go
@@ -10,7 +10,8 @@ import (
 	ds "github.com/bronlabs/bron-crypto/pkg/base/datastructures"
 	"github.com/bronlabs/bron-crypto/pkg/base/datastructures/hashset"
 	"github.com/bronlabs/bron-crypto/pkg/base/utils/sliceutils"
-	"github.com/bronlabs/bron-crypto/pkg/mpc/sharing/internal"
+	"github.com/bronlabs/bron-crypto/pkg/mpc/sharing/accessstructures/internal"
+	sharingInternal "github.com/bronlabs/bron-crypto/pkg/mpc/sharing/internal"
 )
 
 // GateKind distinguishes between internal threshold gates and attribute leaves in the threshold-gate tree.
@@ -25,7 +26,7 @@ type Node struct {
 	kind GateKind
 
 	// for attribute gates
-	attr internal.ID
+	attr sharingInternal.ID
 
 	// for gate nodes
 	threshold int
@@ -36,7 +37,7 @@ type Node struct {
 //
 // Attribute leaves are the terminal nodes of a threshold-gate access tree and
 // correspond to the rows of the induced MSP.
-func ID(id internal.ID) *Node {
+func ID(id sharingInternal.ID) *Node {
 	//nolint:exhaustruct // only attribute properties set
 	return &Node{
 		kind: attribute,
@@ -78,7 +79,7 @@ func Or(nodes ...*Node) *Node {
 // coalition is qualified when it satisfies the root gate.
 type ThresholdGateAccessStructure struct {
 	root         *Node
-	shareholders map[internal.ID]bool
+	shareholders map[sharingInternal.ID]bool
 }
 
 // NewThresholdGateAccessStructure constructs an access structure from a
@@ -90,7 +91,7 @@ func NewThresholdGateAccessStructure(thresholdGateTreeRoot *Node) (*ThresholdGat
 		return nil, errs.Wrap(err).WithMessage("invalid threshold-gate tree")
 	}
 
-	shareholders := make(map[internal.ID]bool)
+	shareholders := make(map[sharingInternal.ID]bool)
 	allShareholders(thresholdGateTreeRoot, shareholders)
 	as := &ThresholdGateAccessStructure{
 		root:         thresholdGateTreeRoot,
@@ -100,8 +101,8 @@ func NewThresholdGateAccessStructure(thresholdGateTreeRoot *Node) (*ThresholdGat
 }
 
 // IsQualified reports whether the given shareholder IDs satisfy the threshold gates.
-func (a *ThresholdGateAccessStructure) IsQualified(ids ...internal.ID) bool {
-	shareholders := map[internal.ID]bool{}
+func (a *ThresholdGateAccessStructure) IsQualified(ids ...sharingInternal.ID) bool {
+	shareholders := map[sharingInternal.ID]bool{}
 	for _, id := range ids {
 		shareholders[id] = true
 	}
@@ -110,14 +111,22 @@ func (a *ThresholdGateAccessStructure) IsQualified(ids ...internal.ID) bool {
 
 // Shareholders returns the set of all shareholder IDs that occur as attribute
 // leaves in the tree.
-func (a *ThresholdGateAccessStructure) Shareholders() ds.Set[internal.ID] {
+func (a *ThresholdGateAccessStructure) Shareholders() ds.Set[sharingInternal.ID] {
 	return hashset.NewComparable(slices.Collect(maps.Keys(a.shareholders))...).Freeze()
 }
 
 // MaximalUnqualifiedSetsIter streams maximal unqualified sets of the access structure.
-func (*ThresholdGateAccessStructure) MaximalUnqualifiedSetsIter() iter.Seq[ds.Set[internal.ID]] {
-	// TODO implement me
-	panic("implement me")
+//
+// This implementation is brute-force and should only be used for small access
+// structures. It also requires every shareholder ID in the access structure to
+// lie in the range [1, 64]; otherwise it panics.
+func (a *ThresholdGateAccessStructure) MaximalUnqualifiedSetsIter() iter.Seq[ds.Set[sharingInternal.ID]] {
+	maxUnqualifiedSetsIter, err := internal.BruteForceMaximalUnqualifiedSets(a.Shareholders(), a.IsQualified)
+	if err != nil {
+		panic(err)
+	}
+
+	return maxUnqualifiedSetsIter
 }
 
 // CountLeaves returns the number of attribute leaves in the threshold-gate
@@ -130,28 +139,28 @@ func (a *ThresholdGateAccessStructure) CountLeaves() int {
 
 func checkTree(node *Node) error {
 	if node == nil {
-		return internal.ErrIsNil.WithMessage("node is nil")
+		return sharingInternal.ErrIsNil.WithMessage("node is nil")
 	}
 	if node.kind == attribute {
 		if node.attr == 0 {
-			return internal.ErrValue.WithMessage("sharing ID cannot be 0")
+			return sharingInternal.ErrValue.WithMessage("sharing ID cannot be 0")
 		}
 		return nil
 	}
 	if node.kind == gate {
 		if node.threshold <= 0 {
-			return internal.ErrValue.WithMessage("threshold must be positive")
+			return sharingInternal.ErrValue.WithMessage("threshold must be positive")
 		}
 		if node.threshold > len(node.children) {
-			return internal.ErrValue.WithMessage("threshold must be less than or equal to the number of children")
+			return sharingInternal.ErrValue.WithMessage("threshold must be less than or equal to the number of children")
 		}
 		attrChildren := sliceutils.Filter(node.children, func(child *Node) bool { return child.kind == attribute })
-		uniqueAttrChildren := make(map[internal.ID]bool)
+		uniqueAttrChildren := make(map[sharingInternal.ID]bool)
 		for _, child := range attrChildren {
 			uniqueAttrChildren[child.attr] = true
 		}
 		if len(uniqueAttrChildren) != len(attrChildren) {
-			return internal.ErrValue.WithMessage("threshold-gate tree must not contain duplicate attribute nodes")
+			return sharingInternal.ErrValue.WithMessage("threshold-gate tree must not contain duplicate attribute nodes")
 		}
 
 		for _, child := range node.children {
@@ -162,10 +171,10 @@ func checkTree(node *Node) error {
 		return nil
 	}
 
-	return internal.ErrValue.WithMessage("unknown node kind")
+	return sharingInternal.ErrValue.WithMessage("unknown node kind")
 }
 
-func allShareholders(node *Node, shareholders map[internal.ID]bool) {
+func allShareholders(node *Node, shareholders map[sharingInternal.ID]bool) {
 	if node == nil || (node.kind != gate && node.kind != attribute) {
 		return
 	}
@@ -179,7 +188,7 @@ func allShareholders(node *Node, shareholders map[internal.ID]bool) {
 	}
 }
 
-func treeEval(node *Node, ids map[internal.ID]bool) bool {
+func treeEval(node *Node, ids map[sharingInternal.ID]bool) bool {
 	if node == nil || (node.kind != gate && node.kind != attribute) {
 		return false
 	}

--- a/pkg/mpc/sharing/accessstructures/boolexpr/boolexpr_test.go
+++ b/pkg/mpc/sharing/accessstructures/boolexpr/boolexpr_test.go
@@ -1,17 +1,22 @@
 package boolexpr_test
 
 import (
+	"fmt"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/bronlabs/bron-crypto/pkg/base/curves/k256"
+	ds "github.com/bronlabs/bron-crypto/pkg/base/datastructures"
 	"github.com/bronlabs/bron-crypto/pkg/base/datastructures/hashset"
 	"github.com/bronlabs/bron-crypto/pkg/base/mat"
 	"github.com/bronlabs/bron-crypto/pkg/base/prng/pcg"
 	"github.com/bronlabs/bron-crypto/pkg/base/utils/sliceutils"
 	"github.com/bronlabs/bron-crypto/pkg/mpc/sharing/accessstructures/boolexpr"
 	"github.com/bronlabs/bron-crypto/pkg/mpc/sharing/accessstructures/unanimity"
+	sharinginternal "github.com/bronlabs/bron-crypto/pkg/mpc/sharing/internal"
 	"github.com/bronlabs/bron-crypto/pkg/mpc/sharing/scheme/kw"
 )
 
@@ -174,4 +179,204 @@ func TestConvertExampleC(t *testing.T) {
 			require.True(t, secretValue.Equal(sum))
 		}
 	})
+}
+
+func TestThresholdGateAccessStructureMaximalUnqualifiedSetsIter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		root *boolexpr.Node
+	}{
+		{
+			name: "5-shareholders",
+			root: boolexpr.Threshold(2,
+				boolexpr.And(
+					boolexpr.ID(1),
+					boolexpr.ID(2),
+				),
+				boolexpr.ID(3),
+				boolexpr.Threshold(2,
+					boolexpr.ID(4),
+					boolexpr.ID(5),
+				),
+			),
+		},
+		{
+			name: "10-shareholders",
+			root: boolexpr.Threshold(2,
+				boolexpr.Threshold(2,
+					boolexpr.ID(1),
+					boolexpr.ID(2),
+					boolexpr.ID(3),
+				),
+				boolexpr.Threshold(2,
+					boolexpr.ID(4),
+					boolexpr.ID(5),
+					boolexpr.ID(6),
+				),
+				boolexpr.Threshold(2,
+					boolexpr.ID(7),
+					boolexpr.ID(8),
+					boolexpr.ID(9),
+					boolexpr.ID(10),
+				),
+			),
+		},
+		{
+			name: "15-shareholders",
+			root: boolexpr.Threshold(2,
+				boolexpr.Threshold(3,
+					boolexpr.ID(1),
+					boolexpr.ID(2),
+					boolexpr.ID(3),
+					boolexpr.ID(4),
+					boolexpr.ID(5),
+				),
+				boolexpr.Threshold(3,
+					boolexpr.ID(6),
+					boolexpr.ID(7),
+					boolexpr.ID(8),
+					boolexpr.ID(9),
+					boolexpr.ID(10),
+				),
+				boolexpr.Threshold(4,
+					boolexpr.ID(11),
+					boolexpr.ID(12),
+					boolexpr.ID(13),
+					boolexpr.ID(14),
+					boolexpr.ID(15),
+				),
+			),
+		},
+		{
+			name: "20-shareholders-deep",
+			root: boolexpr.Threshold(2,
+				boolexpr.And(
+					boolexpr.Or(
+						boolexpr.ID(1),
+						boolexpr.ID(2),
+					),
+					boolexpr.Threshold(2,
+						boolexpr.ID(3),
+						boolexpr.ID(4),
+						boolexpr.ID(5),
+					),
+				),
+				boolexpr.Threshold(2,
+					boolexpr.And(
+						boolexpr.ID(6),
+						boolexpr.Or(
+							boolexpr.ID(7),
+							boolexpr.ID(8),
+							boolexpr.ID(9),
+						),
+					),
+					boolexpr.Threshold(2,
+						boolexpr.ID(10),
+						boolexpr.ID(11),
+						boolexpr.ID(12),
+					),
+					boolexpr.And(
+						boolexpr.ID(13),
+						boolexpr.ID(14),
+					),
+				),
+				boolexpr.Threshold(2,
+					boolexpr.Threshold(2,
+						boolexpr.ID(15),
+						boolexpr.ID(16),
+						boolexpr.ID(17),
+					),
+					boolexpr.And(
+						boolexpr.ID(18),
+						boolexpr.Or(
+							boolexpr.ID(19),
+							boolexpr.ID(20),
+						),
+					),
+				),
+			),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			as, err := boolexpr.NewThresholdGateAccessStructure(tc.root)
+			require.NoError(t, err)
+
+			maxUnqualifiedSets := slices.Collect(as.MaximalUnqualifiedSetsIter())
+			require.Equal(t, referenceBoolexprMaximalUnqualifiedSets(as), canonicalBoolexprSetMap(maxUnqualifiedSets))
+
+			shareholders := as.Shareholders()
+			for _, subset := range maxUnqualifiedSets {
+				require.True(t, subset.IsSubSet(shareholders))
+				require.False(t, as.IsQualified(subset.List()...))
+
+				for id := range shareholders.Iter() {
+					if subset.Contains(id) {
+						continue
+					}
+
+					extended := subset.Unfreeze()
+					extended.Add(id)
+					require.True(t, as.IsQualified(extended.List()...))
+				}
+			}
+		})
+	}
+}
+
+func referenceBoolexprMaximalUnqualifiedSets(as *boolexpr.ThresholdGateAccessStructure) map[string]struct{} {
+	shareholders := as.Shareholders().List()
+	slices.Sort(shareholders)
+
+	out := make(map[string]struct{})
+	for size := 0; size <= len(shareholders); size++ {
+		for combo := range sliceutils.Combinations(shareholders, uint(size)) {
+			subset := hashset.NewComparable(combo...).Freeze()
+			if as.IsQualified(combo...) {
+				continue
+			}
+
+			maximal := true
+			for _, id := range shareholders {
+				if subset.Contains(id) {
+					continue
+				}
+
+				extended := subset.Unfreeze()
+				extended.Add(id)
+				if !as.IsQualified(extended.List()...) {
+					maximal = false
+					break
+				}
+			}
+			if maximal {
+				out[canonicalBoolexprIDs(subset)] = struct{}{}
+			}
+		}
+	}
+
+	return out
+}
+
+func canonicalBoolexprSetMap(sets []ds.Set[sharinginternal.ID]) map[string]struct{} {
+	out := make(map[string]struct{}, len(sets))
+	for _, subset := range sets {
+		out[canonicalBoolexprIDs(subset)] = struct{}{}
+	}
+	return out
+}
+
+func canonicalBoolexprIDs(s ds.Set[sharinginternal.ID]) string {
+	ids := s.List()
+	slices.Sort(ids)
+	parts := make([]string, 0, len(ids))
+	for _, id := range ids {
+		parts = append(parts, fmt.Sprint(id))
+	}
+	return strings.Join(parts, ",")
 }

--- a/pkg/mpc/sharing/accessstructures/hierarchical/README.md
+++ b/pkg/mpc/sharing/accessstructures/hierarchical/README.md
@@ -22,7 +22,9 @@ MSP induction is implemented via `InducedMSP`, which constructs a monotone span 
 from the Birkhoff-Vandermonde matrix. This enables hierarchical access structures to be
 used with the KW MSP-based secret sharing scheme.
 
-Maximal unqualified set enumeration is not yet implemented.
+Maximal unqualified set enumeration is implemented via `MaximalUnqualifiedSetsIter`.
+The current implementation is brute-force and intended only for small access structures.
+It also requires shareholder IDs to lie in the range `1..64`.
 
 ## Reference
 

--- a/pkg/mpc/sharing/accessstructures/hierarchical/hierarchical.go
+++ b/pkg/mpc/sharing/accessstructures/hierarchical/hierarchical.go
@@ -13,12 +13,13 @@ import (
 	"github.com/bronlabs/bron-crypto/pkg/base/polynomials/interpolation/birkhoff"
 	"github.com/bronlabs/bron-crypto/pkg/base/utils/mathutils"
 	"github.com/bronlabs/bron-crypto/pkg/base/utils/sliceutils"
-	"github.com/bronlabs/bron-crypto/pkg/mpc/sharing/internal"
+	"github.com/bronlabs/bron-crypto/pkg/mpc/sharing/accessstructures/internal"
+	sharingIternal "github.com/bronlabs/bron-crypto/pkg/mpc/sharing/internal"
 	"github.com/bronlabs/bron-crypto/pkg/mpc/sharing/scheme/kw/msp"
 )
 
 // ID uniquely identifies a shareholder.
-type ID = internal.ID
+type ID = sharingIternal.ID
 
 // WithLevel constructs a hierarchical threshold level.
 //
@@ -113,8 +114,17 @@ func (h *HierarchicalConjunctiveThreshold) Shareholders() ds.Set[ID] {
 }
 
 // MaximalUnqualifiedSetsIter streams all maximal unqualified sets.
-func (*HierarchicalConjunctiveThreshold) MaximalUnqualifiedSetsIter() iter.Seq[ds.Set[ID]] {
-	panic("not implemented")
+//
+// This implementation is brute-force and should only be used for small access
+// structures. It also requires every shareholder ID in the access structure to
+// lie in the range [1, 64]; otherwise it panics.
+func (h *HierarchicalConjunctiveThreshold) MaximalUnqualifiedSetsIter() iter.Seq[ds.Set[ID]] {
+	maxUnqualifiedSetsIter, err := internal.BruteForceMaximalUnqualifiedSets(h.Shareholders(), h.IsQualified)
+	if err != nil {
+		panic(err)
+	}
+
+	return maxUnqualifiedSetsIter
 }
 
 func (h *HierarchicalConjunctiveThreshold) Rank(id ID) (int, error) {

--- a/pkg/mpc/sharing/accessstructures/hierarchical/hierarchical.go
+++ b/pkg/mpc/sharing/accessstructures/hierarchical/hierarchical.go
@@ -14,12 +14,12 @@ import (
 	"github.com/bronlabs/bron-crypto/pkg/base/utils/mathutils"
 	"github.com/bronlabs/bron-crypto/pkg/base/utils/sliceutils"
 	"github.com/bronlabs/bron-crypto/pkg/mpc/sharing/accessstructures/internal"
-	sharingIternal "github.com/bronlabs/bron-crypto/pkg/mpc/sharing/internal"
+	sharingInternal "github.com/bronlabs/bron-crypto/pkg/mpc/sharing/internal"
 	"github.com/bronlabs/bron-crypto/pkg/mpc/sharing/scheme/kw/msp"
 )
 
 // ID uniquely identifies a shareholder.
-type ID = sharingIternal.ID
+type ID = sharingInternal.ID
 
 // WithLevel constructs a hierarchical threshold level.
 //

--- a/pkg/mpc/sharing/accessstructures/hierarchical/hierarchical_test.go
+++ b/pkg/mpc/sharing/accessstructures/hierarchical/hierarchical_test.go
@@ -2,12 +2,17 @@
 package hierarchical
 
 import (
+	"fmt"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	ds "github.com/bronlabs/bron-crypto/pkg/base/datastructures"
 	"github.com/bronlabs/bron-crypto/pkg/base/datastructures/hashset"
 	"github.com/bronlabs/bron-crypto/pkg/base/serde"
+	"github.com/bronlabs/bron-crypto/pkg/base/utils/sliceutils"
 )
 
 func TestNewHierarchicalConjunctiveThresholdAccessStructure(t *testing.T) {
@@ -171,4 +176,125 @@ func TestHierarchicalConjunctiveThresholdLevelsReturnsSliceCopy(t *testing.T) {
 
 	require.Equal(t, 1, h.Levels()[0].Threshold())
 	require.True(t, h.Levels()[0].Shareholders().Equal(hashset.NewComparable[ID](1, 2).Freeze()))
+}
+
+func TestHierarchicalConjunctiveThresholdMaximalUnqualifiedSetsIter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		levels []*ThresholdLevel
+	}{
+		{
+			name: "two-level(1,2)",
+			levels: []*ThresholdLevel{
+				WithLevel(1, 1, 2),
+				WithLevel(2, 3, 4),
+			},
+		},
+		{
+			name: "three-level(1,2,4)",
+			levels: []*ThresholdLevel{
+				WithLevel(1, 1, 2),
+				WithLevel(2, 3, 4),
+				WithLevel(4, 5, 6),
+			},
+		},
+		{
+			name: "three-level(2,4,5)",
+			levels: []*ThresholdLevel{
+				WithLevel(2, 1, 2, 3),
+				WithLevel(4, 4, 5),
+				WithLevel(5, 6),
+			},
+		},
+		{
+			name: "four-level(2,4,7)",
+			levels: []*ThresholdLevel{
+				WithLevel(2, 1, 2, 3),
+				WithLevel(4, 4, 5, 6, 7),
+				WithLevel(7, 8, 9, 10, 11, 12),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h, err := NewHierarchicalConjunctiveThresholdAccessStructure(tc.levels...)
+			require.NoError(t, err)
+
+			maxUnqualifiedSets := slices.Collect(h.MaximalUnqualifiedSetsIter())
+			require.Equal(t, referenceMaximalUnqualifiedSets(h), canonicalSetMap(maxUnqualifiedSets))
+
+			shareholders := h.Shareholders()
+			for _, subset := range maxUnqualifiedSets {
+				require.True(t, subset.IsSubSet(shareholders))
+				require.False(t, h.IsQualified(subset.List()...))
+
+				for id := range shareholders.Iter() {
+					if subset.Contains(id) {
+						continue
+					}
+
+					extended := subset.Unfreeze()
+					extended.Add(id)
+					require.True(t, h.IsQualified(extended.List()...))
+				}
+			}
+		})
+	}
+}
+
+func referenceMaximalUnqualifiedSets(h *HierarchicalConjunctiveThreshold) map[string]struct{} {
+	shareholders := h.Shareholders().List()
+	slices.Sort(shareholders)
+
+	out := make(map[string]struct{})
+	for size := 0; size <= len(shareholders); size++ {
+		for combo := range sliceutils.Combinations(shareholders, uint(size)) {
+			subset := hashset.NewComparable(combo...).Freeze()
+			if h.IsQualified(combo...) {
+				continue
+			}
+
+			maximal := true
+			for _, id := range shareholders {
+				if subset.Contains(id) {
+					continue
+				}
+
+				extended := subset.Unfreeze()
+				extended.Add(id)
+				if !h.IsQualified(extended.List()...) {
+					maximal = false
+					break
+				}
+			}
+			if maximal {
+				out[canonicalIDs(subset)] = struct{}{}
+			}
+		}
+	}
+
+	return out
+}
+
+func canonicalSetMap(sets []ds.Set[ID]) map[string]struct{} {
+	out := make(map[string]struct{}, len(sets))
+	for _, subset := range sets {
+		out[canonicalIDs(subset)] = struct{}{}
+	}
+	return out
+}
+
+func canonicalIDs(s ds.Set[ID]) string {
+	ids := s.List()
+	slices.Sort(ids)
+	parts := make([]string, 0, len(ids))
+	for _, id := range ids {
+		parts = append(parts, fmt.Sprint(id))
+	}
+	return strings.Join(parts, ",")
 }

--- a/pkg/mpc/sharing/accessstructures/internal/mus.go
+++ b/pkg/mpc/sharing/accessstructures/internal/mus.go
@@ -5,21 +5,15 @@ import (
 	"maps"
 	"slices"
 
-	"github.com/bronlabs/errs-go/errs"
-
 	ds "github.com/bronlabs/bron-crypto/pkg/base/datastructures"
 	"github.com/bronlabs/bron-crypto/pkg/base/datastructures/bitset"
 	"github.com/bronlabs/bron-crypto/pkg/base/datastructures/hashset"
 	"github.com/bronlabs/bron-crypto/pkg/base/utils/sliceutils"
 	"github.com/bronlabs/bron-crypto/pkg/mpc/sharing"
+	sharingInternal "github.com/bronlabs/bron-crypto/pkg/mpc/sharing/internal"
 )
 
-const maxShareholders = 64
-
-var (
-	ErrInvalidArgument = errs.New("invalid argument")
-	ErrOverflow        = errs.New("overflow")
-)
+const maxShareholderID = 64
 
 // BruteForceMaximalUnqualifiedSets returns an iterator over all maximal
 // unqualified subsets of shareholders by exhaustive search.
@@ -38,12 +32,15 @@ var (
 // It returns ErrInvalidArgument for nil/empty inputs and ErrOverflow when any
 // shareholder ID exceeds 64.
 func BruteForceMaximalUnqualifiedSets(shareholders ds.Set[sharing.ID], isQualified func(ids ...sharing.ID) bool) (iter.Seq[ds.Set[sharing.ID]], error) {
-	if shareholders == nil || isQualified == nil || shareholders.Size() < 1 {
-		return nil, ErrInvalidArgument.WithMessage("invalid arguments")
+	if shareholders == nil || isQualified == nil {
+		return nil, sharingInternal.ErrIsNil.WithMessage("invalid arguments")
+	}
+	if shareholders.Size() == 0 {
+		return nil, sharingInternal.ErrValue.WithMessage("shareholders is empty")
 	}
 	sortedShareholders := slices.Sorted(shareholders.Iter())
-	if sortedShareholders[len(sortedShareholders)-1] > maxShareholders {
-		return nil, ErrOverflow.WithMessage("too many shareholders")
+	if sortedShareholders[len(sortedShareholders)-1] > maxShareholderID {
+		return nil, sharingInternal.ErrOverflow.WithMessage("shareholder ID exceeds 64")
 	}
 
 	muss := make(map[bitset.BitSet[sharing.ID]]struct{})

--- a/pkg/mpc/sharing/accessstructures/internal/mus.go
+++ b/pkg/mpc/sharing/accessstructures/internal/mus.go
@@ -1,0 +1,76 @@
+package internal
+
+import (
+	"iter"
+	"maps"
+	"slices"
+
+	"github.com/bronlabs/errs-go/errs"
+
+	ds "github.com/bronlabs/bron-crypto/pkg/base/datastructures"
+	"github.com/bronlabs/bron-crypto/pkg/base/datastructures/bitset"
+	"github.com/bronlabs/bron-crypto/pkg/base/datastructures/hashset"
+	"github.com/bronlabs/bron-crypto/pkg/base/utils/sliceutils"
+	"github.com/bronlabs/bron-crypto/pkg/mpc/sharing"
+)
+
+const maxShareholders = 64
+
+var (
+	ErrInvalidArgument = errs.New("invalid argument")
+	ErrOverflow        = errs.New("overflow")
+)
+
+// BruteForceMaximalUnqualifiedSets returns an iterator over all maximal
+// unqualified subsets of shareholders by exhaustive search.
+//
+// The search enumerates shareholder subsets in descending cardinality and keeps
+// only those unqualified subsets that are not contained in an already-found
+// larger unqualified subset.
+//
+// This helper uses a bitset representation keyed directly by shareholder IDs,
+// so it requires:
+//   - shareholders != nil
+//   - isQualified != nil
+//   - shareholders is non-empty
+//   - every shareholder ID is in the range [1, 64]
+//
+// It returns ErrInvalidArgument for nil/empty inputs and ErrOverflow when any
+// shareholder ID exceeds 64.
+func BruteForceMaximalUnqualifiedSets(shareholders ds.Set[sharing.ID], isQualified func(ids ...sharing.ID) bool) (iter.Seq[ds.Set[sharing.ID]], error) {
+	if shareholders == nil || isQualified == nil || shareholders.Size() < 1 {
+		return nil, ErrInvalidArgument.WithMessage("invalid arguments")
+	}
+	sortedShareholders := slices.Sorted(shareholders.Iter())
+	if sortedShareholders[len(sortedShareholders)-1] > maxShareholders {
+		return nil, ErrOverflow.WithMessage("too many shareholders")
+	}
+
+	muss := make(map[bitset.BitSet[sharing.ID]]struct{})
+	for t := len(sortedShareholders); t >= 1; t-- {
+	next:
+		for s := range sliceutils.Combinations(sortedShareholders, uint(t)) {
+			if isQualified(s...) {
+				continue
+			}
+
+			// s is unqualified, check if it's not a subset of existing unqualified sets
+			s2 := *bitset.NewBitSet(s...)
+			for mus := range maps.Keys(muss) {
+				if s2.IsSubSet(&mus) {
+					continue next
+				}
+			}
+
+			muss[s2] = struct{}{}
+		}
+	}
+
+	return func(yield func(ds.Set[sharing.ID]) bool) {
+		for mus := range muss {
+			if !yield(hashset.NewComparable(mus.List()...).Freeze()) {
+				return
+			}
+		}
+	}, nil
+}

--- a/pkg/mpc/sharing/internal/errors.go
+++ b/pkg/mpc/sharing/internal/errors.go
@@ -9,4 +9,5 @@ var (
 	ErrType          = errs.New("type error")
 	ErrFailed        = errs.New("failed")
 	ErrSerialisation = errs.New("serialisation error")
+	ErrOverflow      = errs.New("overflow")
 )


### PR DESCRIPTION
## Description

## Pull Request Checklist
  This PR implements maximal unqualified set enumeration for:

  - hierarchical conjunctive threshold access structures
  - threshold-gate/boolean-expression access structures

  Both implementations use a shared brute-force helper that exhaustively enumerates maximal unqualified subsets.



### Scope
- [x] Summary and description are provided.
- [x] Changes are focused and scoped to one purpose.

### Testing (select all that apply)
- [ ] Unit tests
- [ ] Property tests
- [ ] Test vectors tests
- [ ] Benchmarks
- [ ] Not run (explain why)

### Documentation / Spec (if relevant)
- [x] Updated/added docs or comments
- [x] Spec updated or linked

### Notes
- [ ] Additional context is provided (if needed)
