### PR TITLE
Add context.Context to network layer.

### DIFF
--- a/pkg/mpc/aor/runner.go
+++ b/pkg/mpc/aor/runner.go
@@ -1,6 +1,7 @@
 package aor
 
 import (
+	"context"
 	"io"
 
 	"github.com/bronlabs/errs-go/errs"
@@ -26,13 +27,13 @@ type agreeOnRandomRunner struct {
 }
 
 // Run executes the three-round Agree-on-Random protocol over the provided message router.
-func (r *agreeOnRandomRunner) Run(rt *network.Router) ([]byte, error) {
+func (r *agreeOnRandomRunner) Run(ctx context.Context, rt *network.Router) ([]byte, error) {
 	// r1
 	r1Out, err := r.participant.Round1()
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 1")
 	}
-	r2In, err := exchange.BroadcastExchange(rt, "AgreeOnRandomRound1Broadcast", r.participant.quorum, r1Out)
+	r2In, err := exchange.BroadcastExchange(ctx, rt, "AgreeOnRandomRound1Broadcast", r.participant.quorum, r1Out)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange broadcast")
 	}
@@ -42,7 +43,7 @@ func (r *agreeOnRandomRunner) Run(rt *network.Router) ([]byte, error) {
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 2")
 	}
-	r3In, err := exchange.BroadcastExchange(rt, "AgreeOnRandomRound2Broadcast", r.participant.quorum, r2Out)
+	r3In, err := exchange.BroadcastExchange(ctx, rt, "AgreeOnRandomRound2Broadcast", r.participant.quorum, r2Out)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange broadcast")
 	}

--- a/pkg/mpc/dkg/canetti/runner.go
+++ b/pkg/mpc/dkg/canetti/runner.go
@@ -1,6 +1,7 @@
 package canetti
 
 import (
+	"context"
 	"io"
 
 	"github.com/bronlabs/errs-go/errs"
@@ -42,13 +43,13 @@ func NewRunner[G algebra.PrimeGroupElement[G, S], S algebra.PrimeFieldElement[S]
 }
 
 // Run executes the protocol against the provided router.
-func (r *runner[G, S]) Run(rt *network.Router) (*mpc.BaseShard[G, S], error) {
+func (r *runner[G, S]) Run(ctx context.Context, rt *network.Router) (*mpc.BaseShard[G, S], error) {
 	// r1
 	r1bOut, err := r.p.Round1()
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 1")
 	}
-	r2bIn, err := exchange.BroadcastExchange(rt, r1CorrelationID, r.p.ctx.Quorum(), r1bOut)
+	r2bIn, err := exchange.BroadcastExchange(ctx, rt, r1CorrelationID, r.p.ctx.Quorum(), r1bOut)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange round 1 messages")
 	}
@@ -58,7 +59,7 @@ func (r *runner[G, S]) Run(rt *network.Router) (*mpc.BaseShard[G, S], error) {
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 2")
 	}
-	r3bIn, r3uIn, err := exchange.Exchange(rt, r2CorrelationID, r.p.ctx.Quorum(), r2bOut, r2uOut)
+	r3bIn, r3uIn, err := exchange.Exchange(ctx, rt, r2CorrelationID, r.p.ctx.Quorum(), r2bOut, r2uOut)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange round 2 messages")
 	}
@@ -68,7 +69,7 @@ func (r *runner[G, S]) Run(rt *network.Router) (*mpc.BaseShard[G, S], error) {
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 3")
 	}
-	r4bIn, err := exchange.BroadcastExchange(rt, r3CorrelationID, r.p.ctx.Quorum(), r3bOut)
+	r4bIn, err := exchange.BroadcastExchange(ctx, rt, r3CorrelationID, r.p.ctx.Quorum(), r3bOut)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange round 3 messages")
 	}

--- a/pkg/mpc/dkg/gennaro/runner.go
+++ b/pkg/mpc/dkg/gennaro/runner.go
@@ -1,6 +1,7 @@
 package gennaro
 
 import (
+	"context"
 	"io"
 
 	"github.com/bronlabs/errs-go/errs"
@@ -28,13 +29,13 @@ func NewRunner[G algebra.PrimeGroupElement[G, S], S algebra.PrimeFieldElement[S]
 }
 
 // Run executes the DKG rounds using the provided router and returns the final output.
-func (r *runner[G, S]) Run(rt *network.Router) (*mpc.BaseShard[G, S], error) {
+func (r *runner[G, S]) Run(ctx context.Context, rt *network.Router) (*mpc.BaseShard[G, S], error) {
 	// r1
 	r1OutB, r1OutU, err := r.party.Round1()
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 1")
 	}
-	r2InB, r2InU, err := exchange.Exchange(rt, "GennaroDKGRound1", r.party.MSP().Shareholders(), r1OutB, r1OutU)
+	r2InB, r2InU, err := exchange.Exchange(ctx, rt, "GennaroDKGRound1", r.party.MSP().Shareholders(), r1OutB, r1OutU)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange broadcast")
 	}
@@ -44,7 +45,7 @@ func (r *runner[G, S]) Run(rt *network.Router) (*mpc.BaseShard[G, S], error) {
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 2")
 	}
-	r3InB, err := exchange.BroadcastExchange(rt, "GennaroDKGRound2", r.party.MSP().Shareholders(), r2OutB)
+	r3InB, err := exchange.BroadcastExchange(ctx, rt, "GennaroDKGRound2", r.party.MSP().Shareholders(), r2OutB)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange broadcast")
 	}

--- a/pkg/mpc/redistribute/runner.go
+++ b/pkg/mpc/redistribute/runner.go
@@ -1,6 +1,7 @@
 package redistribute
 
 import (
+	"context"
 	"io"
 	"slices"
 
@@ -41,18 +42,18 @@ func NewRunner[G algebra.PrimeGroupElement[G, S], S algebra.PrimeFieldElement[S]
 }
 
 // Run executes the redistribution rounds over the provided router.
-func (r *runner[G, S]) Run(rt *network.Router) (*mpc.BaseShard[G, S], error) {
+func (r *runner[G, S]) Run(ctx context.Context, rt *network.Router) (*mpc.BaseShard[G, S], error) {
 	// r1
 	r1bOut, r1uOut, err := r.participant.Round1()
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 1")
 	}
-	r1bIn, err := exchange.BroadcastExchange(rt, r1CorrelationID, r.participant.ctx.Quorum(), r1bOut)
+	r1bIn, err := exchange.BroadcastExchange(ctx, rt, r1CorrelationID, r.participant.ctx.Quorum(), r1bOut)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange round 1 broadcast")
 	}
 	if r1uOut != nil {
-		err = exchange.UnicastSend(rt, r1CorrelationID, r1uOut)
+		err = exchange.UnicastSend(ctx, rt, r1CorrelationID, r1uOut)
 		if err != nil {
 			return nil, errs.Wrap(err).WithMessage("cannot send round 1 p2p")
 		}
@@ -62,7 +63,7 @@ func (r *runner[G, S]) Run(rt *network.Router) (*mpc.BaseShard[G, S], error) {
 	prevSenders := hashset.NewComparable(slices.Collect(r.participant.otherPrevShareholders())...).Freeze()
 	r1uIn := hashmap.NewComparable[sharing.ID, *Round1P2P[G, S]]().Freeze()
 	if r.participant.isPrevShareholder(r.participant.ctx.HolderID()) {
-		r1uIn, err = exchange.UnicastReceive[*Round1P2P[G, S], *Participant[G, S]](rt, r1CorrelationID, prevSenders)
+		r1uIn, err = exchange.UnicastReceive[*Round1P2P[G, S], *Participant[G, S]](ctx, rt, r1CorrelationID, prevSenders)
 		if err != nil {
 			return nil, errs.Wrap(err).WithMessage("cannot receive round 1 p2p")
 		}
@@ -72,12 +73,12 @@ func (r *runner[G, S]) Run(rt *network.Router) (*mpc.BaseShard[G, S], error) {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 2")
 	}
 
-	r2bIn, err := exchange.BroadcastExchange(rt, r2CorrelationID, r.participant.ctx.Quorum(), r2bOut)
+	r2bIn, err := exchange.BroadcastExchange(ctx, rt, r2CorrelationID, r.participant.ctx.Quorum(), r2bOut)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange round 2 broadcast")
 	}
 	if r2uOut != nil {
-		err = exchange.UnicastSend(rt, r2CorrelationID, r2uOut)
+		err = exchange.UnicastSend(ctx, rt, r2CorrelationID, r2uOut)
 		if err != nil {
 			return nil, errs.Wrap(err).WithMessage("cannot send round 2 p2p")
 		}
@@ -86,7 +87,7 @@ func (r *runner[G, S]) Run(rt *network.Router) (*mpc.BaseShard[G, S], error) {
 	// r3
 	r2uIn := hashmap.NewComparable[sharing.ID, *Round2P2P[G, S]]().Freeze()
 	if r.participant.isNextShareholder(r.participant.ctx.HolderID()) {
-		r2uIn, err = exchange.UnicastReceive[*Round2P2P[G, S], *Participant[G, S]](rt, r2CorrelationID, prevSenders)
+		r2uIn, err = exchange.UnicastReceive[*Round2P2P[G, S], *Participant[G, S]](ctx, rt, r2CorrelationID, prevSenders)
 		if err != nil {
 			return nil, errs.Wrap(err).WithMessage("cannot receive round 2 p2p")
 		}

--- a/pkg/mpc/session/runner.go
+++ b/pkg/mpc/session/runner.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"context"
 	"io"
 
 	"github.com/bronlabs/errs-go/errs"
@@ -34,7 +35,7 @@ func NewSessionRunner(id sharing.ID, quorum ds.Set[sharing.ID], prng io.Reader) 
 	return r, nil
 }
 
-func (r *runner) Run(rt *network.Router) (*Context, error) {
+func (r *runner) Run(ctx context.Context, rt *network.Router) (*Context, error) {
 	quorum := hashset.NewComparable(r.party.sortedQuorum...).Freeze()
 
 	// round 1
@@ -42,7 +43,7 @@ func (r *runner) Run(rt *network.Router) (*Context, error) {
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 1")
 	}
-	r2bi, err := exchange.BroadcastExchange(rt, r1CorrelationID, quorum, r1bo)
+	r2bi, err := exchange.BroadcastExchange(ctx, rt, r1CorrelationID, quorum, r1bo)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange broadcast")
 	}
@@ -52,11 +53,11 @@ func (r *runner) Run(rt *network.Router) (*Context, error) {
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 2")
 	}
-	r3bi, err := exchange.BroadcastExchange(rt, r2CorrelationID, quorum, r2bo)
+	r3bi, err := exchange.BroadcastExchange(ctx, rt, r2CorrelationID, quorum, r2bo)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange broadcast")
 	}
-	r3ui, err := exchange.UnicastExchange(rt, r2CorrelationID, r2uo)
+	r3ui, err := exchange.UnicastExchange(ctx, rt, r2CorrelationID, r2uo)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange unicast")
 	}
@@ -66,15 +67,15 @@ func (r *runner) Run(rt *network.Router) (*Context, error) {
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 3")
 	}
-	r4ui, err := exchange.UnicastExchange(rt, r3CorrelationID, r3uo)
+	r4ui, err := exchange.UnicastExchange(ctx, rt, r3CorrelationID, r3uo)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange unicast")
 	}
 
 	// round 4
-	ctx, err := r.party.Round4(r4ui)
+	sessionCtx, err := r.party.Round4(r4ui)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 4")
 	}
-	return ctx, nil
+	return sessionCtx, nil
 }

--- a/pkg/mpc/signatures/ecdsa/dkls23/signing_bbot/runner.go
+++ b/pkg/mpc/signatures/ecdsa/dkls23/signing_bbot/runner.go
@@ -1,6 +1,7 @@
 package signing_bbot
 
 import (
+	"context"
 	"io"
 
 	"github.com/bronlabs/errs-go/errs"
@@ -39,12 +40,12 @@ func NewRunner[P curves.Point[P, B, S], B algebra.PrimeFieldElement[B], S algebr
 	return &signRunner[P, B, S]{cosigner: cosigner, message: message}, nil
 }
 
-func (r *signRunner[P, B, S]) Run(rt *network.Router) (*dkls23.PartialSignature[P, B, S], error) {
+func (r *signRunner[P, B, S]) Run(ctx context.Context, rt *network.Router) (*dkls23.PartialSignature[P, B, S], error) {
 	r1bOut, r1uOut, err := r.cosigner.Round1()
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 1")
 	}
-	r2bIn, r2uIn, err := exchange.Exchange(rt, r1CorrelationID, r.cosigner.ctx.Quorum(), r1bOut, r1uOut)
+	r2bIn, r2uIn, err := exchange.Exchange(ctx, rt, r1CorrelationID, r.cosigner.ctx.Quorum(), r1bOut, r1uOut)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange round 1 messages")
 	}
@@ -53,7 +54,7 @@ func (r *signRunner[P, B, S]) Run(rt *network.Router) (*dkls23.PartialSignature[
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 2")
 	}
-	r3bIn, r3uIn, err := exchange.Exchange(rt, r2CorrelationID, r.cosigner.ctx.Quorum(), r2bOut, r2uOut)
+	r3bIn, r3uIn, err := exchange.Exchange(ctx, rt, r2CorrelationID, r.cosigner.ctx.Quorum(), r2bOut, r2uOut)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange round 2 messages")
 	}
@@ -62,7 +63,7 @@ func (r *signRunner[P, B, S]) Run(rt *network.Router) (*dkls23.PartialSignature[
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 3")
 	}
-	r4bIn, r4uIn, err := exchange.Exchange(rt, r3CorrelationID, r.cosigner.ctx.Quorum(), r3bOut, r3uOut)
+	r4bIn, r4uIn, err := exchange.Exchange(ctx, rt, r3CorrelationID, r.cosigner.ctx.Quorum(), r3bOut, r3uOut)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange round 3 messages")
 	}

--- a/pkg/mpc/signatures/ecdsa/dkls23/signing_softspoken/runner.go
+++ b/pkg/mpc/signatures/ecdsa/dkls23/signing_softspoken/runner.go
@@ -1,6 +1,7 @@
 package signing_softspoken
 
 import (
+	"context"
 	"io"
 
 	"github.com/bronlabs/errs-go/errs"
@@ -40,12 +41,12 @@ func NewRunner[P curves.Point[P, B, S], B algebra.PrimeFieldElement[B], S algebr
 	return &signRunner[P, B, S]{cosigner: cosigner, message: message}, nil
 }
 
-func (r *signRunner[P, B, S]) Run(rt *network.Router) (*dkls23.PartialSignature[P, B, S], error) {
+func (r *signRunner[P, B, S]) Run(ctx context.Context, rt *network.Router) (*dkls23.PartialSignature[P, B, S], error) {
 	r1uOut, err := r.cosigner.Round1()
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 1")
 	}
-	r2uIn, err := exchange.UnicastExchange(rt, r1CorrelationID, r1uOut)
+	r2uIn, err := exchange.UnicastExchange(ctx, rt, r1CorrelationID, r1uOut)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange round 1 messages")
 	}
@@ -54,7 +55,7 @@ func (r *signRunner[P, B, S]) Run(rt *network.Router) (*dkls23.PartialSignature[
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 2")
 	}
-	r3uIn, err := exchange.UnicastExchange(rt, r2CorrelationID, r2uOut)
+	r3uIn, err := exchange.UnicastExchange(ctx, rt, r2CorrelationID, r2uOut)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange round 2 messages")
 	}
@@ -63,7 +64,7 @@ func (r *signRunner[P, B, S]) Run(rt *network.Router) (*dkls23.PartialSignature[
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 3")
 	}
-	r4bIn, r4uIn, err := exchange.Exchange(rt, r3CorrelationID, r.cosigner.ctx.Quorum(), r3bOut, r3uOut)
+	r4bIn, r4uIn, err := exchange.Exchange(ctx, rt, r3CorrelationID, r.cosigner.ctx.Quorum(), r3bOut, r3uOut)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange round 3 messages")
 	}
@@ -72,7 +73,7 @@ func (r *signRunner[P, B, S]) Run(rt *network.Router) (*dkls23.PartialSignature[
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 4")
 	}
-	r5bIn, r5uIn, err := exchange.Exchange(rt, r4CorrelationID, r.cosigner.ctx.Quorum(), r4bOut, r4uOut)
+	r5bIn, r5uIn, err := exchange.Exchange(ctx, rt, r4CorrelationID, r.cosigner.ctx.Quorum(), r4bOut, r4uOut)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange round 4 messages")
 	}

--- a/pkg/mpc/signatures/schnorr/lindell22/signing/runner.go
+++ b/pkg/mpc/signatures/schnorr/lindell22/signing/runner.go
@@ -1,6 +1,7 @@
 package signing
 
 import (
+	"context"
 	"io"
 
 	"github.com/bronlabs/errs-go/errs"
@@ -46,12 +47,12 @@ func NewRunner[
 	}, nil
 }
 
-func (r *signingRunner[GE, S, M]) Run(rt *network.Router) (*lindell22.PartialSignature[GE, S], error) {
+func (r *signingRunner[GE, S, M]) Run(ctx context.Context, rt *network.Router) (*lindell22.PartialSignature[GE, S], error) {
 	r1bOut, r1uOut, err := r.cosigner.Round1()
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 1")
 	}
-	r2bIn, r2uIn, err := exchange.Exchange(rt, r1CorrelationID, r.cosigner.Quorum(), r1bOut, r1uOut)
+	r2bIn, r2uIn, err := exchange.Exchange(ctx, rt, r1CorrelationID, r.cosigner.Quorum(), r1bOut, r1uOut)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange round 1 messages")
 	}
@@ -60,7 +61,7 @@ func (r *signingRunner[GE, S, M]) Run(rt *network.Router) (*lindell22.PartialSig
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 2")
 	}
-	r3bIn, err := exchange.BroadcastExchange(rt, r2CorrelationID, r.cosigner.Quorum(), r2bOut)
+	r3bIn, err := exchange.BroadcastExchange(ctx, rt, r2CorrelationID, r.cosigner.Quorum(), r2bOut)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange round 2 messages")
 	}

--- a/pkg/network/README.md
+++ b/pkg/network/README.md
@@ -12,16 +12,16 @@ Utilities for coordinating multi-party protocols: session identifiers, message r
 
 ## Key Types
 
-- `Delivery`: user-supplied transport with `Send`/`Receive`, `PartyID`, and `Quorum`.
+- `Delivery`: user-supplied transport with context-aware `Send`/`Receive`, `PartyID`, and `Quorum`.
 - `Router`: correlation-aware shim over a `Delivery`; buffers unrelated messages for later retrieval.
-- `Runner`: interface for protocol executors (`Run(rt *Router)`).
+- `Runner`: interface for protocol executors (`Run(ctx context.Context, rt *Router)`).
 - `SID`: 32-byte session identifier derived via SHA3-256 over user-provided blobs.
 
 ## Typical Flow
 
 1. Implement `Delivery` (or use `testutils.MockCoordinator`) for your environment.
 2. Create a `Router` with `NewRouter(delivery)`.
-3. Exchange messages with `SendTo`/`ReceiveFrom` or use helpers like `SendUnicast`/`ReceiveUnicast`.
+3. Exchange messages with `SendTo`/`ReceiveFrom` or use helpers like `SendUnicast`/`ReceiveUnicast`, passing the caller's context.
 4. Compose more complex protocols via runners that accept a `*Router`.
 
 ## Notes

--- a/pkg/network/echo/exchange.go
+++ b/pkg/network/echo/exchange.go
@@ -1,6 +1,8 @@
 package echo
 
 import (
+	"context"
+
 	"github.com/bronlabs/errs-go/errs"
 
 	"github.com/bronlabs/bron-crypto/pkg/base/datastructures/hashmap"
@@ -9,12 +11,12 @@ import (
 )
 
 // ExchangeEchoBroadcast runs an echo broadcast: send, echo, and verify consistent payloads for selected parties.
-func ExchangeEchoBroadcast[B network.Message[P], P any](rt *network.Router, correlationID string, quorum network.Quorum, message B) (network.RoundMessages[B, P], error) {
+func ExchangeEchoBroadcast[B network.Message[P], P any](ctx context.Context, rt *network.Router, correlationID string, quorum network.Quorum, message B) (network.RoundMessages[B, P], error) {
 	r, err := NewEchoBroadcastRunner(rt.PartyID(), quorum, correlationID, message)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("failed to create echo broadcast runner")
 	}
-	result, err := r.Run(rt)
+	result, err := r.Run(ctx, rt)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("failed to run echo broadcast")
 	}

--- a/pkg/network/echo/runner.go
+++ b/pkg/network/echo/runner.go
@@ -1,6 +1,8 @@
 package echo
 
 import (
+	"context"
+
 	"github.com/bronlabs/errs-go/errs"
 
 	"github.com/bronlabs/bron-crypto/pkg/mpc/sharing"
@@ -29,17 +31,17 @@ func NewEchoBroadcastRunner[B network.Message[BP], BP any](sharingID sharing.ID,
 }
 
 // Run executes the three-round echo broadcast protocol over the provided router.
-func (r *echoBroadcastRunner[B, BP]) Run(rt *network.Router) (network.RoundMessages[B, BP], error) {
+func (r *echoBroadcastRunner[B, BP]) Run(ctx context.Context, rt *network.Router) (network.RoundMessages[B, BP], error) {
 	// r1
 	r1Out, err := r.party.Round1(r.message)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("failed to run round 1")
 	}
-	err = network.SendUnicast(rt, r.correlationID+":EchoRound1P2P", r1Out)
+	err = network.SendUnicast(ctx, rt, r.correlationID+":EchoRound1P2P", r1Out)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("failed to send unicast")
 	}
-	r2In, err := network.ReceiveUnicast[*Round1P2P[B, BP], *Participant[B, BP]](rt, r.correlationID+":EchoRound1P2P", r.party.Quorum())
+	r2In, err := network.ReceiveUnicast[*Round1P2P[B, BP], *Participant[B, BP]](ctx, rt, r.correlationID+":EchoRound1P2P", r.party.Quorum())
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("failed to receive unicast")
 	}
@@ -49,11 +51,11 @@ func (r *echoBroadcastRunner[B, BP]) Run(rt *network.Router) (network.RoundMessa
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("failed to run round 2")
 	}
-	err = network.SendUnicast(rt, r.correlationID+":EchoRound2P2P", r2Out)
+	err = network.SendUnicast(ctx, rt, r.correlationID+":EchoRound2P2P", r2Out)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("failed to send unicast")
 	}
-	r3In, err := network.ReceiveUnicast[*Round2P2P[B, BP], *Participant[B, BP]](rt, r.correlationID+":EchoRound2P2P", r.party.Quorum())
+	r3In, err := network.ReceiveUnicast[*Round2P2P[B, BP], *Participant[B, BP]](ctx, rt, r.correlationID+":EchoRound2P2P", r.party.Quorum())
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("failed to receive unicast")
 	}

--- a/pkg/network/exchange.go
+++ b/pkg/network/exchange.go
@@ -1,6 +1,8 @@
 package network
 
 import (
+	"context"
+
 	"github.com/bronlabs/errs-go/errs"
 
 	"github.com/bronlabs/bron-crypto/pkg/base/datastructures/hashmap"
@@ -8,7 +10,7 @@ import (
 	"github.com/bronlabs/bron-crypto/pkg/mpc/sharing"
 )
 
-func SendUnicast[U Message[P], P any](rt *Router, correlationID string, messages RoundMessages[U, P]) error {
+func SendUnicast[U Message[P], P any](ctx context.Context, rt *Router, correlationID string, messages RoundMessages[U, P]) error {
 	messagesSerialized := make(map[sharing.ID][]byte)
 	for id, message := range messages.Iter() {
 		messageSerialized, err := serde.MarshalCBOR(message)
@@ -17,18 +19,18 @@ func SendUnicast[U Message[P], P any](rt *Router, correlationID string, messages
 		}
 		messagesSerialized[id] = messageSerialized
 	}
-	err := rt.SendTo(correlationID, messagesSerialized)
+	err := rt.SendTo(ctx, correlationID, messagesSerialized)
 	if err != nil {
 		return errs.Wrap(err).WithMessage("failed to send messages")
 	}
 	return nil
 }
 
-func ReceiveUnicast[U Message[P], P any](rt *Router, correlationID string, quorum Quorum) (RoundMessages[U, P], error) {
+func ReceiveUnicast[U Message[P], P any](ctx context.Context, rt *Router, correlationID string, quorum Quorum) (RoundMessages[U, P], error) {
 	coparties := quorum.Clone().Unfreeze()
 	coparties.Remove(rt.PartyID())
 
-	receivedMessagesSerialized, err := rt.ReceiveFrom(correlationID, coparties.List()...)
+	receivedMessagesSerialized, err := rt.ReceiveFrom(ctx, correlationID, coparties.List()...)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("failed to exchange messages")
 	}

--- a/pkg/network/exchange/exchange.go
+++ b/pkg/network/exchange/exchange.go
@@ -1,6 +1,8 @@
 package exchange
 
 import (
+	"context"
+
 	"github.com/bronlabs/errs-go/errs"
 
 	"github.com/bronlabs/bron-crypto/pkg/base/datastructures/hashset"
@@ -13,16 +15,16 @@ const (
 	broadcastPrefix = "BROADCAST:"
 )
 
-func UnicastSend[U network.Message[P], P any](rt *network.Router, correlationID string, unicastMessagesOut network.RoundMessages[U, P]) error {
-	err := network.SendUnicast(rt, correlationID+unicastPrefix, unicastMessagesOut)
+func UnicastSend[U network.Message[P], P any](ctx context.Context, rt *network.Router, correlationID string, unicastMessagesOut network.RoundMessages[U, P]) error {
+	err := network.SendUnicast(ctx, rt, correlationID+unicastPrefix, unicastMessagesOut)
 	if err != nil {
 		return errs.Wrap(err).WithMessage("cannot send unicast")
 	}
 	return nil
 }
 
-func UnicastReceive[U network.Message[P], P any](rt *network.Router, correlationID string, quorum network.Quorum) (network.RoundMessages[U, P], error) {
-	unicastMessagesIn, err := network.ReceiveUnicast[U, P](rt, correlationID+unicastPrefix, quorum)
+func UnicastReceive[U network.Message[P], P any](ctx context.Context, rt *network.Router, correlationID string, quorum network.Quorum) (network.RoundMessages[U, P], error) {
+	unicastMessagesIn, err := network.ReceiveUnicast[U, P](ctx, rt, correlationID+unicastPrefix, quorum)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot receive unicast")
 	}
@@ -30,13 +32,13 @@ func UnicastReceive[U network.Message[P], P any](rt *network.Router, correlation
 }
 
 // UnicastExchange performs a unicast-only exchange where each party sends distinct messages.
-func UnicastExchange[U network.Message[P], P any](rt *network.Router, correlationID string, unicastMessagesOut network.RoundMessages[U, P]) (unicastMessagesIn network.RoundMessages[U, P], err error) {
-	err = network.SendUnicast(rt, correlationID+unicastPrefix, unicastMessagesOut)
+func UnicastExchange[U network.Message[P], P any](ctx context.Context, rt *network.Router, correlationID string, unicastMessagesOut network.RoundMessages[U, P]) (unicastMessagesIn network.RoundMessages[U, P], err error) {
+	err = network.SendUnicast(ctx, rt, correlationID+unicastPrefix, unicastMessagesOut)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot send unicast")
 	}
 	quorum := unicastMessagesOut.Keys()
-	unicastMessagesIn, err = network.ReceiveUnicast[U, P](rt, correlationID+unicastPrefix, hashset.NewComparable(quorum...).Freeze())
+	unicastMessagesIn, err = network.ReceiveUnicast[U, P](ctx, rt, correlationID+unicastPrefix, hashset.NewComparable(quorum...).Freeze())
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange unicast")
 	}
@@ -44,8 +46,8 @@ func UnicastExchange[U network.Message[P], P any](rt *network.Router, correlatio
 }
 
 // BroadcastExchange performs an echo-broadcast round with the given message.
-func BroadcastExchange[B network.Message[P], P any](rt *network.Router, correlationID string, quorum network.Quorum, broadcastMessageOut B) (broadcastMessagesIn network.RoundMessages[B, P], err error) {
-	broadcastMessagesIn, err = echo.ExchangeEchoBroadcast[B, P](rt, correlationID+broadcastPrefix, quorum, broadcastMessageOut)
+func BroadcastExchange[B network.Message[P], P any](ctx context.Context, rt *network.Router, correlationID string, quorum network.Quorum, broadcastMessageOut B) (broadcastMessagesIn network.RoundMessages[B, P], err error) {
+	broadcastMessagesIn, err = echo.ExchangeEchoBroadcast[B, P](ctx, rt, correlationID+broadcastPrefix, quorum, broadcastMessageOut)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange broadcast")
 	}
@@ -53,12 +55,12 @@ func BroadcastExchange[B network.Message[P], P any](rt *network.Router, correlat
 }
 
 // Exchange performs a combined broadcast and unicast exchange under a shared correlation ID.
-func Exchange[B network.Message[P], U network.Message[P], P any](rt *network.Router, correlationID string, quorum network.Quorum, broadcastMessageOut B, unicastMessagesOut network.RoundMessages[U, P]) (broadcastMessagesIn network.RoundMessages[B, P], unicastMessagesIn network.RoundMessages[U, P], err error) {
-	broadcastMessagesIn, err = BroadcastExchange(rt, correlationID, quorum, broadcastMessageOut)
+func Exchange[B network.Message[P], U network.Message[P], P any](ctx context.Context, rt *network.Router, correlationID string, quorum network.Quorum, broadcastMessageOut B, unicastMessagesOut network.RoundMessages[U, P]) (broadcastMessagesIn network.RoundMessages[B, P], unicastMessagesIn network.RoundMessages[U, P], err error) {
+	broadcastMessagesIn, err = BroadcastExchange(ctx, rt, correlationID, quorum, broadcastMessageOut)
 	if err != nil {
 		return nil, nil, errs.Wrap(err).WithMessage("cannot exchange broadcast")
 	}
-	unicastMessagesIn, err = UnicastExchange(rt, correlationID, unicastMessagesOut)
+	unicastMessagesIn, err = UnicastExchange(ctx, rt, correlationID, unicastMessagesOut)
 	if err != nil {
 		return nil, nil, errs.Wrap(err).WithMessage("cannot exchange unicast")
 	}

--- a/pkg/network/router.go
+++ b/pkg/network/router.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"bytes"
+	"context"
 	"maps"
 	"slices"
 
@@ -19,8 +20,8 @@ import (
 type Delivery interface {
 	PartyID() sharing.ID
 	Quorum() []sharing.ID
-	Send(to sharing.ID, message []byte) error
-	Receive() (from sharing.ID, message []byte, err error)
+	Send(ctx context.Context, to sharing.ID, message []byte) error
+	Receive(ctx context.Context) (from sharing.ID, message []byte, err error)
 }
 
 // maxReceiveBufferSize caps the number of out-of-order messages the router
@@ -46,7 +47,7 @@ func NewRouter(delivery Delivery) *Router {
 }
 
 // SendTo serialises and sends messages to the given recipients under a correlation identifier.
-func (r *Router) SendTo(correlationID string, messages map[sharing.ID][]byte) error {
+func (r *Router) SendTo(ctx context.Context, correlationID string, messages map[sharing.ID][]byte) error {
 	for id, payload := range messages {
 		//nolint:exhaustruct // From is optional
 		message := routerMessage{
@@ -57,7 +58,7 @@ func (r *Router) SendTo(correlationID string, messages map[sharing.ID][]byte) er
 		if err != nil {
 			return errs.Wrap(err).WithMessage("failed to marshal message")
 		}
-		if err := r.delivery.Send(id, serializedMessage); err != nil {
+		if err := r.delivery.Send(ctx, id, serializedMessage); err != nil {
 			return errs.Wrap(err).WithMessage("failed to send message")
 		}
 	}
@@ -67,7 +68,7 @@ func (r *Router) SendTo(correlationID string, messages map[sharing.ID][]byte) er
 
 // ReceiveFrom collects messages matching the correlation identifier from the specified senders,
 // buffering unrelated messages for later retrieval.
-func (r *Router) ReceiveFrom(correlationID string, froms ...sharing.ID) (map[sharing.ID][]byte, error) {
+func (r *Router) ReceiveFrom(ctx context.Context, correlationID string, froms ...sharing.ID) (map[sharing.ID][]byte, error) {
 	received := make(map[sharing.ID][]byte)
 	expected := map[sharing.ID]struct{}{}
 	for _, from := range froms {
@@ -93,7 +94,7 @@ func (r *Router) ReceiveFrom(correlationID string, froms ...sharing.ID) (map[sha
 	r.receiveBuffer = kept
 
 	for !sliceutils.IsSuperSet(slices.Collect(maps.Keys(received)), froms) {
-		from, serializedMessage, err := r.delivery.Receive()
+		from, serializedMessage, err := r.delivery.Receive(ctx)
 		if err != nil {
 			return nil, errs.Wrap(err).WithMessage("failed to receive message")
 		}

--- a/pkg/network/router_test.go
+++ b/pkg/network/router_test.go
@@ -1,6 +1,7 @@
 package network_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -29,11 +30,11 @@ func (d *stubDelivery) Quorum() []sharing.ID {
 	return d.quorum
 }
 
-func (*stubDelivery) Send(sharing.ID, []byte) error {
+func (*stubDelivery) Send(context.Context, sharing.ID, []byte) error {
 	return nil
 }
 
-func (d *stubDelivery) Receive() (sharing.ID, []byte, error) {
+func (d *stubDelivery) Receive(context.Context) (sharing.ID, []byte, error) {
 	msg := d.queue[0]
 	d.queue = d.queue[1:]
 	return msg.from, msg.message, nil
@@ -69,7 +70,7 @@ func TestRouterReceiveFromFiltersUnexpectedSenders(t *testing.T) {
 	}
 
 	router := network.NewRouter(delivery)
-	received, err := router.ReceiveFrom("cid", 2)
+	received, err := router.ReceiveFrom(context.Background(), "cid", 2)
 	require.NoError(t, err)
 	require.Equal(t, map[sharing.ID][]byte{2: []byte("expected")}, received)
 }

--- a/pkg/network/runner.go
+++ b/pkg/network/runner.go
@@ -1,10 +1,14 @@
 package network
 
-import "github.com/bronlabs/errs-go/errs"
+import (
+	"context"
+
+	"github.com/bronlabs/errs-go/errs"
+)
 
 // Runner executes a networked protocol using a Router and returns its output.
 type Runner[O any] interface {
-	Run(rt *Router) (O, error)
+	Run(ctx context.Context, rt *Router) (O, error)
 }
 
 func NewSafeRunner[O any](r Runner[O]) (Runner[O], error) {
@@ -20,7 +24,7 @@ type safeRunner[O any] struct {
 	r Runner[O]
 }
 
-func (r *safeRunner[O]) Run(rt *Router) (out O, err error) {
+func (r *safeRunner[O]) Run(ctx context.Context, rt *Router) (out O, err error) {
 	defer func() {
 		if recovered := recover(); recovered != nil {
 			switch v := recovered.(type) {
@@ -33,5 +37,5 @@ func (r *safeRunner[O]) Run(rt *Router) (out O, err error) {
 	}()
 
 	//nolint:wrapcheck // intentionally not wrapping the error
-	return r.r.Run(rt)
+	return r.r.Run(ctx, rt)
 }

--- a/pkg/network/runner_test.go
+++ b/pkg/network/runner_test.go
@@ -1,6 +1,7 @@
 package network_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -9,11 +10,11 @@ import (
 )
 
 type stubRunner[O any] struct {
-	run func(*network.Router) (O, error)
+	run func(context.Context, *network.Router) (O, error)
 }
 
-func (r stubRunner[O]) Run(rt *network.Router) (O, error) {
-	return r.run(rt)
+func (r stubRunner[O]) Run(ctx context.Context, rt *network.Router) (O, error) {
+	return r.run(ctx, rt)
 }
 
 func TestSafeRunnerRun(t *testing.T) {
@@ -23,13 +24,13 @@ func TestSafeRunnerRun(t *testing.T) {
 		t.Parallel()
 
 		r, err := network.NewSafeRunner[int](stubRunner[int]{
-			run: func(*network.Router) (int, error) {
+			run: func(context.Context, *network.Router) (int, error) {
 				return 7, nil
 			},
 		})
 		require.NoError(t, err)
 
-		got, err := r.Run(nil)
+		got, err := r.Run(context.Background(), nil)
 		require.NoError(t, err)
 		require.Equal(t, 7, got)
 	})
@@ -38,13 +39,13 @@ func TestSafeRunnerRun(t *testing.T) {
 		t.Parallel()
 
 		r, err := network.NewSafeRunner[int](stubRunner[int]{
-			run: func(*network.Router) (int, error) {
+			run: func(context.Context, *network.Router) (int, error) {
 				panic("boom")
 			},
 		})
 		require.NoError(t, err)
 
-		got, err := r.Run(nil)
+		got, err := r.Run(context.Background(), nil)
 		require.Error(t, err)
 		require.Zero(t, got)
 		require.Contains(t, err.Error(), "runner panicked")

--- a/pkg/network/testutils/coordinator.go
+++ b/pkg/network/testutils/coordinator.go
@@ -1,12 +1,14 @@
 package ntu
 
 import (
+	"context"
 	"maps"
 	"slices"
 
-	"github.com/bronlabs/bron-crypto/pkg/network"
-	"github.com/bronlabs/bron-crypto/pkg/mpc/sharing"
 	"github.com/bronlabs/errs-go/errs"
+
+	"github.com/bronlabs/bron-crypto/pkg/mpc/sharing"
+	"github.com/bronlabs/bron-crypto/pkg/network"
 )
 
 const messageBufferSize = 128
@@ -67,23 +69,40 @@ func (d *mockDelivery) Quorum() []sharing.ID {
 }
 
 // Send enqueues a message to the destination's channel.
-func (d *mockDelivery) Send(sharingID sharing.ID, payload []byte) error {
-	payloadClone := make([]byte, len(payload))
-	copy(payloadClone, payload)
+func (d *mockDelivery) Send(ctx context.Context, sharingID sharing.ID, payload []byte) error {
 	sendChan, ok := d.sendChannels[sharingID]
 	if !ok {
 		return errs.Wrap(network.ErrFailed).WithMessage("no channel for recipient")
 	}
+	if err := ctx.Err(); err != nil {
+		return errs.Wrap(err).WithMessage("context canceled while sending message")
+	}
 
-	sendChan <- deliveryMessage{
+	payloadClone := make([]byte, len(payload))
+	copy(payloadClone, payload)
+	msg := deliveryMessage{
 		From:    d.sharingID,
 		Payload: payloadClone,
 	}
-	return nil
+
+	select {
+	case <-ctx.Done():
+		return errs.Wrap(ctx.Err()).WithMessage("context canceled while sending message")
+	case sendChan <- msg:
+		return nil
+	}
 }
 
 // Receive blocks until a message is available for the party.
-func (d *mockDelivery) Receive() (from sharing.ID, payload []byte, err error) {
-	msg := <-d.receiveChannel
-	return msg.From, msg.Payload, nil
+func (d *mockDelivery) Receive(ctx context.Context) (from sharing.ID, payload []byte, err error) {
+	if err := ctx.Err(); err != nil {
+		return 0, nil, errs.Wrap(err).WithMessage("context canceled while receiving message")
+	}
+
+	select {
+	case <-ctx.Done():
+		return 0, nil, errs.Wrap(ctx.Err()).WithMessage("context canceled while receiving message")
+	case msg := <-d.receiveChannel:
+		return msg.From, msg.Payload, nil
+	}
 }

--- a/pkg/network/testutils/executor.go
+++ b/pkg/network/testutils/executor.go
@@ -1,15 +1,17 @@
 package ntu
 
 import (
+	"context"
 	"maps"
 	"slices"
 	"sync"
 	"testing"
 
-	"github.com/bronlabs/bron-crypto/pkg/network"
-	"github.com/bronlabs/bron-crypto/pkg/mpc/sharing"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/bronlabs/bron-crypto/pkg/mpc/sharing"
+	"github.com/bronlabs/bron-crypto/pkg/network"
 )
 
 // TestExecuteRunners concurrently executes the given runners with mock deliveries and collects their outputs.
@@ -24,7 +26,7 @@ func TestExecuteRunners[O any](tb testing.TB, runners map[sharing.ID]network.Run
 	for id, runner := range runners {
 		errGroup.Go(func() error {
 			rt := network.NewRouter(testCoordinator.DeliveryFor(id))
-			result, err := runner.Run(rt)
+			result, err := runner.Run(context.Background(), rt)
 			if err != nil {
 				return err
 			}
@@ -53,7 +55,7 @@ func TestExecuteRunnersWithQuorum[O any](tb testing.TB, quorum network.Quorum, r
 	for id, runner := range runners {
 		errGroup.Go(func() error {
 			rt := network.NewRouter(testCoordinator.DeliveryFor(id))
-			result, err := runner.Run(rt)
+			result, err := runner.Run(context.Background(), rt)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Description

Adds `context.Context` propagation through the network delivery/exchange path.

This updates `Delivery`, `Router`, `Runner`, unicast/broadcast exchange helpers, echo broadcast, and MPC protocol runners so caller-provided contexts reach the blocking send/receive operations. The in-memory `MockCoordinator`/`mockDelivery` now respects context cancellation while sending to full channels or receiving from empty channels.

Also updates network tests, test utilities, and README references for the new context-aware signatures.

## Pull Request Checklist

### Scope
- [x] Summary and description are provided.
- [x] Changes are focused and scoped to one purpose.

### Testing (select all that apply)
- [x] Unit tests
- [ ] Property tests
- [ ] Test vectors tests
- [ ] Benchmarks
- [ ] Not run (explain why)

### Documentation / Spec (if relevant)
- [x] Updated/added docs or comments
- [ ] Spec updated or linked

### Notes
- [x] Additional context is provided (if needed)

This is an API-breaking change for network callers: `Runner.Run`, router send/receive methods, and exchange helpers now require a `context.Context`.
