### PR TITLE
Add runner notifications.

### DIFF
--- a/pkg/mpc/aor/runner.go
+++ b/pkg/mpc/aor/runner.go
@@ -12,6 +12,11 @@ import (
 	"github.com/bronlabs/bron-crypto/pkg/transcripts"
 )
 
+const (
+	// ProtocolName identifies the Agree-on-Random runner in notifications.
+	ProtocolName = "AgreeOnRandom"
+)
+
 // NewAgreeOnRandomRunner constructs a runner that executes the Agree-on-Random protocol.
 func NewAgreeOnRandomRunner(id sharing.ID, quorum network.Quorum, sampleSize int, tape transcripts.Transcript, prng io.Reader) (network.Runner[[]byte], error) {
 	party, err := NewParticipant(id, quorum, sampleSize, tape, prng)
@@ -27,32 +32,35 @@ type agreeOnRandomRunner struct {
 }
 
 // Run executes the three-round Agree-on-Random protocol over the provided message router.
-func (r *agreeOnRandomRunner) Run(ctx context.Context, rt *network.Router) ([]byte, error) {
+func (r *agreeOnRandomRunner) Run(ctx context.Context, rt *network.Router, notificationCallback network.NotificationCallback) ([]byte, error) {
 	// r1
 	r1Out, err := r.participant.Round1()
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 1")
 	}
+	network.NotifyRoundCompleted(notificationCallback, ProtocolName, 1)
+
+	// r2
 	r2In, err := exchange.BroadcastExchange(ctx, rt, "AgreeOnRandomRound1Broadcast", r.participant.quorum, r1Out)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange broadcast")
 	}
-
-	// r2
 	r2Out, err := r.participant.Round2(r2In)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 2")
 	}
+	network.NotifyRoundCompleted(notificationCallback, ProtocolName, 2)
+
+	// r3
 	r3In, err := exchange.BroadcastExchange(ctx, rt, "AgreeOnRandomRound2Broadcast", r.participant.quorum, r2Out)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange broadcast")
 	}
-
-	// r3
 	sample, err := r.participant.Round3(r3In)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 3")
 	}
+	network.NotifyRoundCompleted(notificationCallback, ProtocolName, 3)
 
 	return sample, nil
 }

--- a/pkg/mpc/aor/runner_test.go
+++ b/pkg/mpc/aor/runner_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/bronlabs/bron-crypto/pkg/base/prng/pcg"
+	"github.com/bronlabs/bron-crypto/pkg/mpc/aor"
 	tu "github.com/bronlabs/bron-crypto/pkg/mpc/aor/testutils"
 	ntu "github.com/bronlabs/bron-crypto/pkg/network/testutils"
 	ttu "github.com/bronlabs/bron-crypto/pkg/transcripts/testutils"
@@ -39,7 +40,7 @@ func testHappyPathRunner(t *testing.T, total int) {
 	quorum := ntu.MakeRandomQuorum(t, prng, total)
 	tapes := ttu.MakeRandomTapes(t, prng, quorum)
 	runners := tu.MakeAgreeOnRandomRunners(t, quorum, tapes, sampleLength)
-	samples := ntu.TestExecuteRunners(t, runners)
+	samples, notifications := ntu.TestExecuteRunners(t, runners)
 
 	t.Run("should generate valid samples", func(t *testing.T) {
 		t.Parallel()
@@ -66,5 +67,10 @@ func testHappyPathRunner(t *testing.T, total int) {
 				require.True(t, slices.Equal(tapeValues[i-1], tapeValues[i]))
 			}
 		}
+	})
+
+	t.Run("notifications are consistent", func(t *testing.T) {
+		t.Parallel()
+		ntu.RequireRoundCompletedNotifications(t, notifications, quorum, aor.ProtocolName, 3)
 	})
 }

--- a/pkg/mpc/dkg/canetti/runner.go
+++ b/pkg/mpc/dkg/canetti/runner.go
@@ -15,6 +15,9 @@ import (
 )
 
 const (
+	// ProtocolName identifies the Canetti DKG runner in notifications.
+	ProtocolName = "Canetti_DKG"
+
 	r1CorrelationID = "BRON_CRYPTO_DKG_CANETTI_R1"
 	r2CorrelationID = "BRON_CRYPTO_DKG_CANETTI_R2"
 	r3CorrelationID = "BRON_CRYPTO_DKG_CANETTI_R3"
@@ -43,41 +46,45 @@ func NewRunner[G algebra.PrimeGroupElement[G, S], S algebra.PrimeFieldElement[S]
 }
 
 // Run executes the protocol against the provided router.
-func (r *runner[G, S]) Run(ctx context.Context, rt *network.Router) (*mpc.BaseShard[G, S], error) {
+func (r *runner[G, S]) Run(ctx context.Context, rt *network.Router, callback network.NotificationCallback) (*mpc.BaseShard[G, S], error) {
 	// r1
 	r1bOut, err := r.p.Round1()
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 1")
 	}
+	network.NotifyRoundCompleted(callback, ProtocolName, 1)
+
+	// r2
 	r2bIn, err := exchange.BroadcastExchange(ctx, rt, r1CorrelationID, r.p.ctx.Quorum(), r1bOut)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange round 1 messages")
 	}
-
-	// r2
 	r2bOut, r2uOut, err := r.p.Round2(r2bIn)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 2")
 	}
+	network.NotifyRoundCompleted(callback, ProtocolName, 2)
+
+	// r3
 	r3bIn, r3uIn, err := exchange.Exchange(ctx, rt, r2CorrelationID, r.p.ctx.Quorum(), r2bOut, r2uOut)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange round 2 messages")
 	}
-
-	// r3
 	r3bOut, err := r.p.Round3(r3bIn, r3uIn)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 3")
 	}
+	network.NotifyRoundCompleted(callback, ProtocolName, 3)
+
+	// r4
 	r4bIn, err := exchange.BroadcastExchange(ctx, rt, r3CorrelationID, r.p.ctx.Quorum(), r3bOut)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange round 3 messages")
 	}
-
-	// r4
 	shard, err := r.p.Round4(r4bIn)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 4")
 	}
+	network.NotifyRoundCompleted(callback, ProtocolName, 4)
 	return shard, err
 }

--- a/pkg/mpc/dkg/canetti/runner_test.go
+++ b/pkg/mpc/dkg/canetti/runner_test.go
@@ -65,7 +65,7 @@ func testHappyPathRunner[G algebra.PrimeGroupElement[G, S], S algebra.PrimeField
 		runners[id], err = canetti.NewRunner(ctxs[id], accessStructure, group, pcg.NewRandomised())
 		require.NoError(t, err)
 	}
-	shards := ntu.TestExecuteRunners(t, runners)
+	shards, notifications := ntu.TestExecuteRunners(t, runners)
 
 	t.Run("public materials are consistent", func(t *testing.T) {
 		t.Parallel()
@@ -117,5 +117,10 @@ func testHappyPathRunner[G algebra.PrimeGroupElement[G, S], S algebra.PrimeField
 		for s := 1; s < len(tapeSamples); s++ {
 			require.True(t, bytes.Equal(tapeSamples[s-1], tapeSamples[s]))
 		}
+	})
+
+	t.Run("notifications are consistent", func(t *testing.T) {
+		t.Parallel()
+		ntu.RequireRoundCompletedNotifications(t, notifications, quorum, canetti.ProtocolName, 4)
 	})
 }

--- a/pkg/mpc/dkg/gennaro/runner.go
+++ b/pkg/mpc/dkg/gennaro/runner.go
@@ -15,6 +15,11 @@ import (
 	"github.com/bronlabs/bron-crypto/pkg/proofs/sigma/compiler"
 )
 
+const (
+	// ProtocolName identifies the Gennaro DKG runner in notifications.
+	ProtocolName = "Gennaro_DKG"
+)
+
 type runner[G algebra.PrimeGroupElement[G, S], S algebra.PrimeFieldElement[S]] struct {
 	party *Participant[G, S]
 }
@@ -29,32 +34,35 @@ func NewRunner[G algebra.PrimeGroupElement[G, S], S algebra.PrimeFieldElement[S]
 }
 
 // Run executes the DKG rounds using the provided router and returns the final output.
-func (r *runner[G, S]) Run(ctx context.Context, rt *network.Router) (*mpc.BaseShard[G, S], error) {
+func (r *runner[G, S]) Run(ctx context.Context, rt *network.Router, notificationCallback network.NotificationCallback) (*mpc.BaseShard[G, S], error) {
 	// r1
 	r1OutB, r1OutU, err := r.party.Round1()
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 1")
 	}
+	network.NotifyRoundCompleted(notificationCallback, ProtocolName, 1)
+
+	// r2
 	r2InB, r2InU, err := exchange.Exchange(ctx, rt, "GennaroDKGRound1", r.party.MSP().Shareholders(), r1OutB, r1OutU)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange broadcast")
 	}
-
-	// r2
 	r2OutB, err := r.party.Round2(r2InB, r2InU)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 2")
 	}
+	network.NotifyRoundCompleted(notificationCallback, ProtocolName, 2)
+
+	// r3
 	r3InB, err := exchange.BroadcastExchange(ctx, rt, "GennaroDKGRound2", r.party.MSP().Shareholders(), r2OutB)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange broadcast")
 	}
-
-	// r3
 	dkgOutput, err := r.party.Round3(r3InB)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 3")
 	}
+	network.NotifyRoundCompleted(notificationCallback, ProtocolName, 3)
 
 	return dkgOutput, nil
 }

--- a/pkg/mpc/dkg/gennaro/runner_test.go
+++ b/pkg/mpc/dkg/gennaro/runner_test.go
@@ -6,12 +6,15 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/bronlabs/bron-crypto/pkg/base/algebra"
 	"github.com/bronlabs/bron-crypto/pkg/base/curves/p256"
 	"github.com/bronlabs/bron-crypto/pkg/base/curves/pairable/bls12381"
 	"github.com/bronlabs/bron-crypto/pkg/base/prng/pcg"
 	"github.com/bronlabs/bron-crypto/pkg/base/utils/iterutils"
 	"github.com/bronlabs/bron-crypto/pkg/mpc"
+	"github.com/bronlabs/bron-crypto/pkg/mpc/dkg/gennaro"
 	tu "github.com/bronlabs/bron-crypto/pkg/mpc/dkg/gennaro/testutils"
 	session_testutils "github.com/bronlabs/bron-crypto/pkg/mpc/session/testutils"
 	"github.com/bronlabs/bron-crypto/pkg/mpc/sharing/accessstructures"
@@ -20,7 +23,6 @@ import (
 	ntu "github.com/bronlabs/bron-crypto/pkg/network/testutils"
 	"github.com/bronlabs/bron-crypto/pkg/proofs/sigma/compiler"
 	"github.com/bronlabs/bron-crypto/pkg/proofs/sigma/compiler/fiatshamir"
-	"github.com/stretchr/testify/require"
 )
 
 func TestRunnerHappyPath(t *testing.T) {
@@ -59,7 +61,7 @@ func testRunnerHappyPath[G algebra.PrimeGroupElement[G, S], S algebra.PrimeField
 	ctxs := session_testutils.MakeRandomContexts(t, quorum, prng)
 
 	runners := tu.MakeGennaroDKGRunners(t, ctxs, ac, niCompiler, group)
-	dkgOutputs := ntu.TestExecuteRunners(t, runners)
+	dkgOutputs, notifications := ntu.TestExecuteRunners(t, runners)
 
 	t.Run("public materials are consistent", func(t *testing.T) {
 		t.Parallel()
@@ -143,5 +145,10 @@ func testRunnerHappyPath[G algebra.PrimeGroupElement[G, S], S algebra.PrimeField
 		for s := 1; s < len(tapeSamples); s++ {
 			require.True(t, bytes.Equal(tapeSamples[s-1], tapeSamples[s]))
 		}
+	})
+
+	t.Run("notifications are consistent", func(t *testing.T) {
+		t.Parallel()
+		ntu.RequireRoundCompletedNotifications(t, notifications, quorum, gennaro.ProtocolName, 3)
 	})
 }

--- a/pkg/mpc/redistribute/runner.go
+++ b/pkg/mpc/redistribute/runner.go
@@ -20,6 +20,9 @@ import (
 )
 
 const (
+	// ProtocolName identifies the redistribution runner in notifications.
+	ProtocolName = "Redistribute"
+
 	r1CorrelationID = "RedistributeRound1"
 	r2CorrelationID = "RedistributeRound2"
 )
@@ -42,12 +45,15 @@ func NewRunner[G algebra.PrimeGroupElement[G, S], S algebra.PrimeFieldElement[S]
 }
 
 // Run executes the redistribution rounds over the provided router.
-func (r *runner[G, S]) Run(ctx context.Context, rt *network.Router) (*mpc.BaseShard[G, S], error) {
+func (r *runner[G, S]) Run(ctx context.Context, rt *network.Router, notificationCallback network.NotificationCallback) (*mpc.BaseShard[G, S], error) {
 	// r1
 	r1bOut, r1uOut, err := r.participant.Round1()
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 1")
 	}
+	network.NotifyRoundCompleted(notificationCallback, ProtocolName, 1)
+
+	// r2
 	r1bIn, err := exchange.BroadcastExchange(ctx, rt, r1CorrelationID, r.participant.ctx.Quorum(), r1bOut)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange round 1 broadcast")
@@ -58,8 +64,6 @@ func (r *runner[G, S]) Run(ctx context.Context, rt *network.Router) (*mpc.BaseSh
 			return nil, errs.Wrap(err).WithMessage("cannot send round 1 p2p")
 		}
 	}
-
-	// r2
 	prevSenders := hashset.NewComparable(slices.Collect(r.participant.otherPrevShareholders())...).Freeze()
 	r1uIn := hashmap.NewComparable[sharing.ID, *Round1P2P[G, S]]().Freeze()
 	if r.participant.isPrevShareholder(r.participant.ctx.HolderID()) {
@@ -72,7 +76,9 @@ func (r *runner[G, S]) Run(ctx context.Context, rt *network.Router) (*mpc.BaseSh
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 2")
 	}
+	network.NotifyRoundCompleted(notificationCallback, ProtocolName, 2)
 
+	// r3
 	r2bIn, err := exchange.BroadcastExchange(ctx, rt, r2CorrelationID, r.participant.ctx.Quorum(), r2bOut)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange round 2 broadcast")
@@ -83,8 +89,6 @@ func (r *runner[G, S]) Run(ctx context.Context, rt *network.Router) (*mpc.BaseSh
 			return nil, errs.Wrap(err).WithMessage("cannot send round 2 p2p")
 		}
 	}
-
-	// r3
 	r2uIn := hashmap.NewComparable[sharing.ID, *Round2P2P[G, S]]().Freeze()
 	if r.participant.isNextShareholder(r.participant.ctx.HolderID()) {
 		r2uIn, err = exchange.UnicastReceive[*Round2P2P[G, S], *Participant[G, S]](ctx, rt, r2CorrelationID, prevSenders)
@@ -96,6 +100,7 @@ func (r *runner[G, S]) Run(ctx context.Context, rt *network.Router) (*mpc.BaseSh
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 3")
 	}
+	network.NotifyRoundCompleted(notificationCallback, ProtocolName, 3)
 
 	return output, nil
 }

--- a/pkg/mpc/redistribute/runner_test.go
+++ b/pkg/mpc/redistribute/runner_test.go
@@ -58,7 +58,8 @@ func testRunnerHappyRecover[G algebra.PrimeGroupElement[G, S], S algebra.PrimeFi
 		runners[id] = runner
 	}
 
-	newShards := ntu.TestExecuteRunners(tb, runners)
+	newShards, notifications := ntu.TestExecuteRunners(tb, runners)
+	ntu.RequireRoundCompletedNotifications(tb, notifications, shareholders, redistribute.ProtocolName, 3)
 
 	scheme, err := feldman.NewScheme(group, as)
 	require.NoError(tb, err)
@@ -104,7 +105,8 @@ func testRunnerHappyRecoverNoTrustedAnchor[G algebra.PrimeGroupElement[G, S], S 
 		runners[id] = runner
 	}
 
-	newShards := ntu.TestExecuteRunners(tb, runners)
+	newShards, notifications := ntu.TestExecuteRunners(tb, runners)
+	ntu.RequireRoundCompletedNotifications(tb, notifications, shareholders, redistribute.ProtocolName, 3)
 
 	scheme, err := feldman.NewScheme(group, as)
 	require.NoError(tb, err)

--- a/pkg/mpc/session/runner.go
+++ b/pkg/mpc/session/runner.go
@@ -14,6 +14,9 @@ import (
 )
 
 const (
+	// ProtocolName identifies the session setup runner in notifications.
+	ProtocolName = "SessionSetup"
+
 	r1CorrelationID = "SessionSetupR1"
 	r2CorrelationID = "SessionSetupR2"
 	r3CorrelationID = "SessionSetupR3"
@@ -35,7 +38,7 @@ func NewSessionRunner(id sharing.ID, quorum ds.Set[sharing.ID], prng io.Reader) 
 	return r, nil
 }
 
-func (r *runner) Run(ctx context.Context, rt *network.Router) (*Context, error) {
+func (r *runner) Run(ctx context.Context, rt *network.Router, notificationCallback network.NotificationCallback) (*Context, error) {
 	quorum := hashset.NewComparable(r.party.sortedQuorum...).Freeze()
 
 	// round 1
@@ -43,16 +46,20 @@ func (r *runner) Run(ctx context.Context, rt *network.Router) (*Context, error) 
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 1")
 	}
+	network.NotifyRoundCompleted(notificationCallback, ProtocolName, 1)
+
+	// round 2
 	r2bi, err := exchange.BroadcastExchange(ctx, rt, r1CorrelationID, quorum, r1bo)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange broadcast")
 	}
-
-	// round 2
 	r2bo, r2uo, err := r.party.Round2(r2bi)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 2")
 	}
+	network.NotifyRoundCompleted(notificationCallback, ProtocolName, 2)
+
+	// round 3
 	r3bi, err := exchange.BroadcastExchange(ctx, rt, r2CorrelationID, quorum, r2bo)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange broadcast")
@@ -61,21 +68,22 @@ func (r *runner) Run(ctx context.Context, rt *network.Router) (*Context, error) 
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange unicast")
 	}
-
-	// round 3
 	r3uo, err := r.party.Round3(r3bi, r3ui)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 3")
 	}
+	network.NotifyRoundCompleted(notificationCallback, ProtocolName, 3)
+
+	// round 4
 	r4ui, err := exchange.UnicastExchange(ctx, rt, r3CorrelationID, r3uo)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange unicast")
 	}
-
-	// round 4
 	sessionCtx, err := r.party.Round4(r4ui)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 4")
 	}
+	network.NotifyRoundCompleted(notificationCallback, ProtocolName, 4)
+
 	return sessionCtx, nil
 }

--- a/pkg/mpc/session/runner_test.go
+++ b/pkg/mpc/session/runner_test.go
@@ -26,7 +26,7 @@ func TestHappyPathRunner(t *testing.T) {
 		runners[id] = r
 	}
 
-	contexts := ntu.TestExecuteRunners(t, runners)
+	contexts, notifications := ntu.TestExecuteRunners(t, runners)
 	t.Run("should agree on session id", func(t *testing.T) {
 		t.Parallel()
 		sid := contexts[quorum.List()[0]].SessionID()
@@ -58,5 +58,10 @@ func TestHappyPathRunner(t *testing.T) {
 			sum = sum.Op(share.Value())
 		}
 		require.True(t, sum.IsOpIdentity())
+	})
+
+	t.Run("notifications are consistent", func(t *testing.T) {
+		t.Parallel()
+		ntu.RequireRoundCompletedNotifications(t, notifications, quorum, session.ProtocolName, 4)
 	})
 }

--- a/pkg/mpc/signatures/ecdsa/dkls23/signing_bbot/runner.go
+++ b/pkg/mpc/signatures/ecdsa/dkls23/signing_bbot/runner.go
@@ -16,6 +16,9 @@ import (
 )
 
 const (
+	// ProtocolName identifies the DKLS23 BBOT signing runner in notifications.
+	ProtocolName = "DKLS23_Signing_BBOT"
+
 	r1CorrelationID = "DKLS23SignBBOTRound1"
 	r2CorrelationID = "DKLS23SignBBOTRound2"
 	r3CorrelationID = "DKLS23SignBBOTRound3"
@@ -40,37 +43,46 @@ func NewRunner[P curves.Point[P, B, S], B algebra.PrimeFieldElement[B], S algebr
 	return &signRunner[P, B, S]{cosigner: cosigner, message: message}, nil
 }
 
-func (r *signRunner[P, B, S]) Run(ctx context.Context, rt *network.Router) (*dkls23.PartialSignature[P, B, S], error) {
+func (r *signRunner[P, B, S]) Run(ctx context.Context, rt *network.Router, notificationCallback network.NotificationCallback) (*dkls23.PartialSignature[P, B, S], error) {
+	// r1
 	r1bOut, r1uOut, err := r.cosigner.Round1()
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 1")
 	}
+	network.NotifyRoundCompleted(notificationCallback, ProtocolName, 1)
+
+	// r2
 	r2bIn, r2uIn, err := exchange.Exchange(ctx, rt, r1CorrelationID, r.cosigner.ctx.Quorum(), r1bOut, r1uOut)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange round 1 messages")
 	}
-
 	r2bOut, r2uOut, err := r.cosigner.Round2(r2bIn, r2uIn)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 2")
 	}
+	network.NotifyRoundCompleted(notificationCallback, ProtocolName, 2)
+
+	// r3
 	r3bIn, r3uIn, err := exchange.Exchange(ctx, rt, r2CorrelationID, r.cosigner.ctx.Quorum(), r2bOut, r2uOut)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange round 2 messages")
 	}
-
 	r3bOut, r3uOut, err := r.cosigner.Round3(r3bIn, r3uIn)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 3")
 	}
+	network.NotifyRoundCompleted(notificationCallback, ProtocolName, 3)
+
+	// r4
 	r4bIn, r4uIn, err := exchange.Exchange(ctx, rt, r3CorrelationID, r.cosigner.ctx.Quorum(), r3bOut, r3uOut)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange round 3 messages")
 	}
-
 	psig, err := r.cosigner.Round4(r4bIn, r4uIn, r.message)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 4")
 	}
+	network.NotifyRoundCompleted(notificationCallback, ProtocolName, 4)
+
 	return psig, nil
 }

--- a/pkg/mpc/signatures/ecdsa/dkls23/signing_bbot/runner_test.go
+++ b/pkg/mpc/signatures/ecdsa/dkls23/signing_bbot/runner_test.go
@@ -57,8 +57,9 @@ func TestRunner_HappyPath(t *testing.T) {
 		runners[id] = runner
 	}
 
-	partialSignatures := ntu.TestExecuteRunners(t, runners)
+	partialSignatures, notifications := ntu.TestExecuteRunners(t, runners)
 	require.Len(t, partialSignatures, signingQuorum.Size())
+	ntu.RequireRoundCompletedNotifications(t, notifications, signingQuorum, signing_bbot.ProtocolName, 4)
 
 	publicKey := slices.Collect(maps.Values(shards))[0].PublicKey()
 	signature, err := dkls23.Aggregate(suite, publicKey, message, slices.Collect(maps.Values(partialSignatures))...)

--- a/pkg/mpc/signatures/ecdsa/dkls23/signing_softspoken/runner.go
+++ b/pkg/mpc/signatures/ecdsa/dkls23/signing_softspoken/runner.go
@@ -16,6 +16,9 @@ import (
 )
 
 const (
+	// ProtocolName identifies the DKLS23 soft-spoken signing runner in notifications.
+	ProtocolName = "DKLS23_Signing_SoftSpoken"
+
 	r1CorrelationID = "DKLS23SignRound1"
 	r2CorrelationID = "DKLS23SignRound2"
 	r3CorrelationID = "DKLS23SignRound3"
@@ -41,46 +44,57 @@ func NewRunner[P curves.Point[P, B, S], B algebra.PrimeFieldElement[B], S algebr
 	return &signRunner[P, B, S]{cosigner: cosigner, message: message}, nil
 }
 
-func (r *signRunner[P, B, S]) Run(ctx context.Context, rt *network.Router) (*dkls23.PartialSignature[P, B, S], error) {
+func (r *signRunner[P, B, S]) Run(ctx context.Context, rt *network.Router, notificationCallback network.NotificationCallback) (*dkls23.PartialSignature[P, B, S], error) {
+	// r1
 	r1uOut, err := r.cosigner.Round1()
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 1")
 	}
+	network.NotifyRoundCompleted(notificationCallback, ProtocolName, 1)
+
+	// r2
 	r2uIn, err := exchange.UnicastExchange(ctx, rt, r1CorrelationID, r1uOut)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange round 1 messages")
 	}
-
 	r2uOut, err := r.cosigner.Round2(r2uIn)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 2")
 	}
+	network.NotifyRoundCompleted(notificationCallback, ProtocolName, 2)
+
+	// r3
 	r3uIn, err := exchange.UnicastExchange(ctx, rt, r2CorrelationID, r2uOut)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange round 2 messages")
 	}
-
 	r3bOut, r3uOut, err := r.cosigner.Round3(r3uIn)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 3")
 	}
+	network.NotifyRoundCompleted(notificationCallback, ProtocolName, 3)
+
+	// r4
 	r4bIn, r4uIn, err := exchange.Exchange(ctx, rt, r3CorrelationID, r.cosigner.ctx.Quorum(), r3bOut, r3uOut)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange round 3 messages")
 	}
-
 	r4bOut, r4uOut, err := r.cosigner.Round4(r4bIn, r4uIn)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 4")
 	}
+	network.NotifyRoundCompleted(notificationCallback, ProtocolName, 4)
+
+	// r5
 	r5bIn, r5uIn, err := exchange.Exchange(ctx, rt, r4CorrelationID, r.cosigner.ctx.Quorum(), r4bOut, r4uOut)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange round 4 messages")
 	}
-
 	psig, err := r.cosigner.Round5(r5bIn, r5uIn, r.message)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 5")
 	}
+	network.NotifyRoundCompleted(notificationCallback, ProtocolName, 5)
+
 	return psig, nil
 }

--- a/pkg/mpc/signatures/ecdsa/dkls23/signing_softspoken/runner_test.go
+++ b/pkg/mpc/signatures/ecdsa/dkls23/signing_softspoken/runner_test.go
@@ -57,8 +57,9 @@ func TestRunner_HappyPath(t *testing.T) {
 		runners[id] = runner
 	}
 
-	partialSignatures := ntu.TestExecuteRunners(t, runners)
+	partialSignatures, notifications := ntu.TestExecuteRunners(t, runners)
 	require.Len(t, partialSignatures, signingQuorum.Size())
+	ntu.RequireRoundCompletedNotifications(t, notifications, signingQuorum, signing_softspoken.ProtocolName, 5)
 
 	publicKey := slices.Collect(maps.Values(shards))[0].PublicKey()
 	signature, err := dkls23.Aggregate(suite, publicKey, message, slices.Collect(maps.Values(partialSignatures))...)

--- a/pkg/mpc/signatures/schnorr/lindell22/signing/runner.go
+++ b/pkg/mpc/signatures/schnorr/lindell22/signing/runner.go
@@ -17,6 +17,9 @@ import (
 )
 
 const (
+	// ProtocolName identifies the Lindell22 signing runner in notifications.
+	ProtocolName = "Lindell22_Signing"
+
 	r1CorrelationID = "Lindell22SigningRound1"
 	r2CorrelationID = "Lindell22SigningRound2"
 )
@@ -47,28 +50,35 @@ func NewRunner[
 	}, nil
 }
 
-func (r *signingRunner[GE, S, M]) Run(ctx context.Context, rt *network.Router) (*lindell22.PartialSignature[GE, S], error) {
+func (r *signingRunner[GE, S, M]) Run(ctx context.Context, rt *network.Router, notificationCallback network.NotificationCallback) (*lindell22.PartialSignature[GE, S], error) {
+	// r1
 	r1bOut, r1uOut, err := r.cosigner.Round1()
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 1")
 	}
+	network.NotifyRoundCompleted(notificationCallback, ProtocolName, 1)
+
+	// r2
 	r2bIn, r2uIn, err := exchange.Exchange(ctx, rt, r1CorrelationID, r.cosigner.Quorum(), r1bOut, r1uOut)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange round 1 messages")
 	}
-
 	r2bOut, err := r.cosigner.Round2(r2bIn, r2uIn)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 2")
 	}
+	network.NotifyRoundCompleted(notificationCallback, ProtocolName, 2)
+
+	// r3
 	r3bIn, err := exchange.BroadcastExchange(ctx, rt, r2CorrelationID, r.cosigner.Quorum(), r2bOut)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot exchange round 2 messages")
 	}
-
 	psig, err := r.cosigner.Round3(r3bIn, r.message)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("cannot run round 3")
 	}
+	network.NotifyRoundCompleted(notificationCallback, ProtocolName, 3)
+
 	return psig, nil
 }

--- a/pkg/mpc/signatures/schnorr/lindell22/signing/signing_test.go
+++ b/pkg/mpc/signatures/schnorr/lindell22/signing/signing_test.go
@@ -97,8 +97,9 @@ func signAndAggregate(
 		runners[id] = runner
 	}
 
-	partialSignatures := ntu.TestExecuteRunners(t, runners)
+	partialSignatures, notifications := ntu.TestExecuteRunners(t, runners)
 	require.Len(t, partialSignatures, len(quorumIDs))
+	ntu.RequireRoundCompletedNotifications(t, notifications, quorumSet, signing.ProtocolName, 3)
 
 	anyID := quorumIDs[0]
 	aggregator, err := signing.NewAggregator(shards[anyID].PublicKeyMaterial(), scheme)
@@ -387,7 +388,8 @@ func TestSigning_TranscriptConsistency(t *testing.T) {
 		runners[id] = runner
 	}
 
-	ntu.TestExecuteRunners(t, runners)
+	_, notifications := ntu.TestExecuteRunners(t, runners)
+	ntu.RequireRoundCompletedNotifications(t, notifications, quorumSet, signing.ProtocolName, 3)
 
 	// All parties' transcripts must be identical.
 	firstTape, err := signingCtxs[quorum[0]].Transcript().ExtractBytes("test", 32)
@@ -446,8 +448,9 @@ func TestSigning_RunnerEndToEnd(t *testing.T) {
 			// DKG via runners
 			dkgCtxs := session_testutils.MakeRandomContexts(t, fx.ac.Shareholders(), prng)
 			dkgRunners := dkgtu.MakeGennaroDKGRunners(t, dkgCtxs, fx.ac, fiatshamir.Name, group)
-			dkgOutputs := ntu.TestExecuteRunners(t, dkgRunners)
+			dkgOutputs, dkgNotifications := ntu.TestExecuteRunners(t, dkgRunners)
 			require.Len(t, dkgOutputs, len(fx.shareholders))
+			ntu.RequireRoundCompletedNotifications(t, dkgNotifications, fx.ac.Shareholders(), gennaro.ProtocolName, 3)
 
 			shards := make(map[sharing.ID]*lindell22.Shard[*k256.Point, *k256.Scalar])
 			for id, output := range dkgOutputs {
@@ -469,8 +472,9 @@ func TestSigning_RunnerEndToEnd(t *testing.T) {
 				runners[id] = runner
 			}
 
-			partialSigs := ntu.TestExecuteRunners(t, runners)
+			partialSigs, notifications := ntu.TestExecuteRunners(t, runners)
 			require.Len(t, partialSigs, len(quorum))
+			ntu.RequireRoundCompletedNotifications(t, notifications, quorumSet, signing.ProtocolName, 3)
 
 			aggregator, err := signing.NewAggregator(shards[quorum[0]].PublicKeyMaterial(), scheme)
 			require.NoError(t, err)

--- a/pkg/network/README.md
+++ b/pkg/network/README.md
@@ -14,7 +14,7 @@ Utilities for coordinating multi-party protocols: session identifiers, message r
 
 - `Delivery`: user-supplied transport with context-aware `Send`/`Receive`, `PartyID`, and `Quorum`.
 - `Router`: correlation-aware shim over a `Delivery`; buffers unrelated messages for later retrieval.
-- `Runner`: interface for protocol executors (`Run(ctx context.Context, rt *Router)`).
+- `Runner`: interface for protocol executors (`Run(ctx context.Context, rt *Router, notificationCallback NotificationCallback)`).
 - `SID`: 32-byte session identifier derived via SHA3-256 over user-provided blobs.
 
 ## Typical Flow

--- a/pkg/network/echo/exchange.go
+++ b/pkg/network/echo/exchange.go
@@ -16,7 +16,7 @@ func ExchangeEchoBroadcast[B network.Message[P], P any](ctx context.Context, rt 
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("failed to create echo broadcast runner")
 	}
-	result, err := r.Run(ctx, rt)
+	result, err := r.Run(ctx, rt, nil)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("failed to run echo broadcast")
 	}

--- a/pkg/network/echo/runner.go
+++ b/pkg/network/echo/runner.go
@@ -31,7 +31,7 @@ func NewEchoBroadcastRunner[B network.Message[BP], BP any](sharingID sharing.ID,
 }
 
 // Run executes the three-round echo broadcast protocol over the provided router.
-func (r *echoBroadcastRunner[B, BP]) Run(ctx context.Context, rt *network.Router) (network.RoundMessages[B, BP], error) {
+func (r *echoBroadcastRunner[B, BP]) Run(ctx context.Context, rt *network.Router, _ network.NotificationCallback) (network.RoundMessages[B, BP], error) {
 	// r1
 	r1Out, err := r.party.Round1(r.message)
 	if err != nil {

--- a/pkg/network/notification.go
+++ b/pkg/network/notification.go
@@ -1,0 +1,50 @@
+package network
+
+import (
+	"time"
+)
+
+var _ Notification = (*RoundCompletedNotification)(nil)
+
+const (
+	// RoundCompletedNotificationType identifies notifications emitted after a protocol round succeeds.
+	RoundCompletedNotificationType NotificationType = "ROUND_COMPLETED"
+)
+
+// NotifyRoundCompleted emits a round-completed notification when callback is non-nil.
+func NotifyRoundCompleted(callback NotificationCallback, protocolName string, round int) {
+	if callback != nil {
+		callback(&RoundCompletedNotification{
+			protocolName: protocolName,
+			round:        round,
+			timestamp:    time.Now(),
+		})
+	}
+}
+
+// RoundCompletedNotification reports that a protocol runner completed a local round.
+type RoundCompletedNotification struct {
+	protocolName string
+	round        int
+	timestamp    time.Time
+}
+
+// Type returns the notification type.
+func (*RoundCompletedNotification) Type() NotificationType {
+	return RoundCompletedNotificationType
+}
+
+// Timestamp returns the notification creation time.
+func (n *RoundCompletedNotification) Timestamp() time.Time {
+	return n.timestamp
+}
+
+// Round returns the completed protocol round.
+func (n *RoundCompletedNotification) Round() int {
+	return n.round
+}
+
+// ProtocolName returns the protocol name that emitted the notification.
+func (n *RoundCompletedNotification) ProtocolName() string {
+	return n.protocolName
+}

--- a/pkg/network/runner.go
+++ b/pkg/network/runner.go
@@ -2,15 +2,29 @@ package network
 
 import (
 	"context"
+	"time"
 
 	"github.com/bronlabs/errs-go/errs"
 )
 
-// Runner executes a networked protocol using a Router and returns its output.
-type Runner[O any] interface {
-	Run(ctx context.Context, rt *Router) (O, error)
+// NotificationType identifies a protocol runner notification kind.
+type NotificationType string
+
+// Notification is an event emitted by a protocol runner.
+type Notification interface {
+	Type() NotificationType
+	Timestamp() time.Time
 }
 
+// NotificationCallback receives protocol runner notifications.
+type NotificationCallback func(n Notification)
+
+// Runner executes a networked protocol using a Router and returns its output.
+type Runner[O any] interface {
+	Run(ctx context.Context, rt *Router, notificationCallback NotificationCallback) (O, error)
+}
+
+// NewSafeRunner wraps a runner and converts panics from Run into errors.
 func NewSafeRunner[O any](r Runner[O]) (Runner[O], error) {
 	if r == nil {
 		return nil, errs.New("runner is nil")
@@ -24,7 +38,7 @@ type safeRunner[O any] struct {
 	r Runner[O]
 }
 
-func (r *safeRunner[O]) Run(ctx context.Context, rt *Router) (out O, err error) {
+func (r *safeRunner[O]) Run(ctx context.Context, rt *Router, notificationCallback NotificationCallback) (out O, err error) {
 	defer func() {
 		if recovered := recover(); recovered != nil {
 			switch v := recovered.(type) {
@@ -37,5 +51,5 @@ func (r *safeRunner[O]) Run(ctx context.Context, rt *Router) (out O, err error) 
 	}()
 
 	//nolint:wrapcheck // intentionally not wrapping the error
-	return r.r.Run(ctx, rt)
+	return r.r.Run(ctx, rt, notificationCallback)
 }

--- a/pkg/network/runner_test.go
+++ b/pkg/network/runner_test.go
@@ -10,11 +10,11 @@ import (
 )
 
 type stubRunner[O any] struct {
-	run func(context.Context, *network.Router) (O, error)
+	run func(context.Context, *network.Router, network.NotificationCallback) (O, error)
 }
 
-func (r stubRunner[O]) Run(ctx context.Context, rt *network.Router) (O, error) {
-	return r.run(ctx, rt)
+func (r stubRunner[O]) Run(ctx context.Context, rt *network.Router, notificationCallback network.NotificationCallback) (O, error) {
+	return r.run(ctx, rt, notificationCallback)
 }
 
 func TestSafeRunnerRun(t *testing.T) {
@@ -24,13 +24,13 @@ func TestSafeRunnerRun(t *testing.T) {
 		t.Parallel()
 
 		r, err := network.NewSafeRunner[int](stubRunner[int]{
-			run: func(context.Context, *network.Router) (int, error) {
+			run: func(context.Context, *network.Router, network.NotificationCallback) (int, error) {
 				return 7, nil
 			},
 		})
 		require.NoError(t, err)
 
-		got, err := r.Run(context.Background(), nil)
+		got, err := r.Run(context.Background(), nil, nil)
 		require.NoError(t, err)
 		require.Equal(t, 7, got)
 	})
@@ -39,13 +39,13 @@ func TestSafeRunnerRun(t *testing.T) {
 		t.Parallel()
 
 		r, err := network.NewSafeRunner[int](stubRunner[int]{
-			run: func(context.Context, *network.Router) (int, error) {
+			run: func(context.Context, *network.Router, network.NotificationCallback) (int, error) {
 				panic("boom")
 			},
 		})
 		require.NoError(t, err)
 
-		got, err := r.Run(context.Background(), nil)
+		got, err := r.Run(context.Background(), nil, nil)
 		require.Error(t, err)
 		require.Zero(t, got)
 		require.Contains(t, err.Error(), "runner panicked")

--- a/pkg/network/testutils/executor.go
+++ b/pkg/network/testutils/executor.go
@@ -14,11 +14,12 @@ import (
 	"github.com/bronlabs/bron-crypto/pkg/network"
 )
 
-// TestExecuteRunners concurrently executes the given runners with mock deliveries and collects their outputs.
-func TestExecuteRunners[O any](tb testing.TB, runners map[sharing.ID]network.Runner[O]) map[sharing.ID]O {
+// TestExecuteRunners concurrently executes the given runners with mock deliveries and collects their outputs and notifications.
+func TestExecuteRunners[O any](tb testing.TB, runners map[sharing.ID]network.Runner[O]) (resultsMap map[sharing.ID]O, notificationsMap map[sharing.ID][]network.Notification) {
 	tb.Helper()
 
-	results := make(map[sharing.ID]O)
+	resultsMap = make(map[sharing.ID]O)
+	notificationsMap = make(map[sharing.ID][]network.Notification)
 	var resultsMutex sync.Mutex
 	testCoordinator := NewMockCoordinator(slices.Collect(maps.Keys(runners))...)
 
@@ -26,28 +27,35 @@ func TestExecuteRunners[O any](tb testing.TB, runners map[sharing.ID]network.Run
 	for id, runner := range runners {
 		errGroup.Go(func() error {
 			rt := network.NewRouter(testCoordinator.DeliveryFor(id))
-			result, err := runner.Run(context.Background(), rt)
+
+			var notifications []network.Notification
+			notificationCallback := func(n network.Notification) {
+				notifications = append(notifications, n)
+			}
+			result, err := runner.Run(context.Background(), rt, notificationCallback)
 			if err != nil {
 				return err
 			}
 
 			resultsMutex.Lock()
 			defer resultsMutex.Unlock()
-			results[id] = result
+			resultsMap[id] = result
+			notificationsMap[id] = notifications
 			return nil
 		})
 	}
 
 	err := errGroup.Wait()
 	require.NoError(tb, err)
-	return results
+	return resultsMap, notificationsMap
 }
 
-// TestExecuteRunners concurrently executes the given runners with mock deliveries and collects their outputs.
-func TestExecuteRunnersWithQuorum[O any](tb testing.TB, quorum network.Quorum, runners map[sharing.ID]network.Runner[O]) map[sharing.ID]O {
+// TestExecuteRunnersWithQuorum concurrently executes the given runners with mock deliveries and collects their outputs and notifications.
+func TestExecuteRunnersWithQuorum[O any](tb testing.TB, quorum network.Quorum, runners map[sharing.ID]network.Runner[O]) (resultsMap map[sharing.ID]O, notificationsMap map[sharing.ID][]network.Notification) {
 	tb.Helper()
 
-	results := make(map[sharing.ID]O)
+	resultsMap = make(map[sharing.ID]O)
+	notificationsMap = make(map[sharing.ID][]network.Notification)
 	var resultsMutex sync.Mutex
 	testCoordinator := NewMockCoordinator(quorum.List()...)
 
@@ -55,19 +63,43 @@ func TestExecuteRunnersWithQuorum[O any](tb testing.TB, quorum network.Quorum, r
 	for id, runner := range runners {
 		errGroup.Go(func() error {
 			rt := network.NewRouter(testCoordinator.DeliveryFor(id))
-			result, err := runner.Run(context.Background(), rt)
+
+			var notifications []network.Notification
+			notificationCallback := func(n network.Notification) {
+				notifications = append(notifications, n)
+			}
+			result, err := runner.Run(context.Background(), rt, notificationCallback)
 			if err != nil {
 				return err
 			}
 
 			resultsMutex.Lock()
 			defer resultsMutex.Unlock()
-			results[id] = result
+			resultsMap[id] = result
+			notificationsMap[id] = notifications
 			return nil
 		})
 	}
 
 	err := errGroup.Wait()
 	require.NoError(tb, err)
-	return results
+	return resultsMap, notificationsMap
+}
+
+// RequireRoundCompletedNotifications checks that each party emitted the expected round-completed notifications.
+func RequireRoundCompletedNotifications(tb testing.TB, notifications map[sharing.ID][]network.Notification, quorum network.Quorum, protocolName string, rounds int) {
+	tb.Helper()
+
+	for id := range quorum.Iter() {
+		partyNotifications := notifications[id]
+		require.Len(tb, partyNotifications, rounds)
+		for i, n := range partyNotifications {
+			roundCompleted, ok := n.(*network.RoundCompletedNotification)
+			require.True(tb, ok)
+			require.Equal(tb, network.RoundCompletedNotificationType, roundCompleted.Type())
+			require.Equal(tb, protocolName, roundCompleted.ProtocolName())
+			require.Equal(tb, i+1, roundCompleted.Round())
+			require.False(tb, roundCompleted.Timestamp().IsZero())
+		}
+	}
 }


### PR DESCRIPTION
## Description

  Adds round-completed notifications to MPC runners consistently with the Canetti DKG runner integration.

  This PR:
  - Adds the `network.Notification` API and `RoundCompletedNotification`.
  - Updates `network.Runner` to accept a `NotificationCallback`.
  - Emits round-completed notifications from AOR, session setup, Canetti DKG, Gennaro DKG, redistribution, Lindell22 signing, DKLS23 BBOT signing, and DKLS23 SoftSpoken signing.
  - Updates mock/test execution helpers to collect runner notifications.
  - Adds shared notification assertions for protocol name, round order, type, and timestamp.
  - Updates runner tests to validate notification behavior.
  - Updates network README/docs/comments for the new runner signature.

## Pull Request Checklist

### Scope
  - [x] Summary and description are provided.
  - [x] Changes are focused and scoped to one purpose.

### Testing (select all that apply)
  - [x] Unit tests
  - [ ] Property tests
  - [ ] Test vectors tests
  - [ ] Benchmarks
  - [ ] Not run (explain why)

### Documentation / Spec (if relevant)
  - [x] Updated/added docs or comments
  - [ ] Spec updated or linked

### Notes
  - [x] Additional context is provided (if needed)
