### PR TITLE
security: harden scalar arithmetic, serialization, CI, and misuse-resistant crypto APIs - DONE BY GPT 5,5 PRO EXTENDED

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,17 +6,35 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
     env:
       GODEBUG: "cpu.avx2=off"
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           clean: true
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install lint tools
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
 
       - name: Build
         run: make build test lint

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,116 @@
+name: Security
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
+  security-events: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  policy:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          clean: true
+          persist-credentials: false
+
+      - name: Verify workflow policy
+        run: make workflow-policy-check
+
+      - name: Verify BoringSSL pin
+        run: scripts/ci/verify-boringssl-pin.sh
+
+      - name: Verify unsafe API policy
+        run: make unsafe-api-check
+
+      - name: Verify constant-time policy
+        run: make ct-check
+
+  govulncheck:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    env:
+      GODEBUG: "cpu.avx2=off"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          clean: true
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run govulncheck
+        run: make govulncheck
+
+  codeql:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          clean: true
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@52485aec7be33610227643b0fe83936b8b5f061a
+        with:
+          languages: go
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@52485aec7be33610227643b0fe83936b8b5f061a
+
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          clean: true
+          persist-credentials: false
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48
+
+  sbom:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          clean: true
+          persist-credentials: false
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610
+        with:
+          path: .
+          format: cyclonedx-json
+          output-file: sbom.cdx.json
+
+      - name: Upload SBOM
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: sbom-cyclonedx-json
+          path: sbom.cdx.json

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ docs/build/*
 /docs/papers
 /coverage.out
 /coverage.html
+/sbom.modules.json

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,23 @@
 BRON_CRYPTO_HOME := $(dir $(lastword $(MAKEFILE_LIST)))
-BORINGSSL_TAG := 0.20251124.0
 BORINGSSL_URL := https://github.com/google/boringssl
+BORINGSSL_COMMIT := 79048f1f1d8e6b7f9ca59b95c24486c8149122a4
 BORINGSSL_HOME := ${BRON_CRYPTO_HOME}/thirdparty/boringssl/
 BORINGSSL_INCLUDE := ${BORINGSSL_HOME}/include
 BORINGSSL_LIB := ${BORINGSSL_HOME}/${BUILD_PREFIX}build/
+GOVULNCHECK := go run golang.org/x/vuln/cmd/govulncheck@v1.3.0
 
 .PHONY: all
 all: build sbom
 
+.PHONY: sbom
+sbom:
+	go list -m -json all > sbom.modules.json
+
 ${BORINGSSL_INCLUDE}/openssl:
-	git clone --depth 1 --branch "${BORINGSSL_TAG}" "${BORINGSSL_URL}" "${BORINGSSL_HOME}"
+	git clone --filter=blob:none --no-checkout "${BORINGSSL_URL}" "${BORINGSSL_HOME}"
+	git -C "${BORINGSSL_HOME}" fetch --depth 1 origin "${BORINGSSL_COMMIT}"
+	git -C "${BORINGSSL_HOME}" checkout --detach "${BORINGSSL_COMMIT}"
+	test "$$(git -C "${BORINGSSL_HOME}" rev-parse HEAD)" = "${BORINGSSL_COMMIT}"
 
 ${BORINGSSL_LIB}/libcrypto.a: ${BORINGSSL_INCLUDE}/openssl
 	cmake "${BORINGSSL_HOME}" -DCMAKE_BUILD_TYPE=Release -DOPENSSL_SMALL=1 -GNinja -B "${BORINGSSL_LIB}"
@@ -50,8 +58,34 @@ lint: build-boringssl
 lint-fix: build-boringssl
 	CGO_CFLAGS="-I$(abspath ${BORINGSSL_INCLUDE})" CGO_LDFLAGS="-L$(abspath ${BORINGSSL_LIB}) -lcrypto" golangci-lint run "${BRON_CRYPTO_HOME}/..." --fix
 
+.PHONY: govulncheck
+govulncheck: build-boringssl
+	CGO_CFLAGS="-I$(abspath ${BORINGSSL_INCLUDE})" CGO_LDFLAGS="-L$(abspath ${BORINGSSL_LIB}) -lcrypto" $(GOVULNCHECK) "${BRON_CRYPTO_HOME}/..."
+
+.PHONY: ct-check
+ct-check:
+	"${BRON_CRYPTO_HOME}/scripts/ci/ct-check.sh"
+
+.PHONY: workflow-policy-check
+workflow-policy-check:
+	"${BRON_CRYPTO_HOME}/scripts/ci/verify-workflows.sh"
+
+.PHONY: boringssl-pin-check
+boringssl-pin-check:
+	"${BRON_CRYPTO_HOME}/scripts/ci/verify-boringssl-pin.sh"
+
+.PHONY: unsafe-api-check
+unsafe-api-check:
+	"${BRON_CRYPTO_HOME}/scripts/ci/unsafe-api-check.sh"
+
+.PHONY: fuzz-smoke
+fuzz-smoke: build-boringssl
+	CGO_CFLAGS="-I$(abspath ${BORINGSSL_INCLUDE})" CGO_LDFLAGS="-L$(abspath ${BORINGSSL_LIB}) -lcrypto" go test "${BRON_CRYPTO_HOME}/pkg/base/serde/..." "${BRON_CRYPTO_HOME}/pkg/network/..."
+
+.PHONY: security
+security: ct-check workflow-policy-check boringssl-pin-check unsafe-api-check govulncheck
+
 .PHONY: clean
 clean:
 	go clean -cache
 	rm -rf "${BORINGSSL_HOME}"
-

--- a/pkg/base/algebra/impl/mul.go
+++ b/pkg/base/algebra/impl/mul.go
@@ -24,27 +24,69 @@ func ScalarMulLowLevel[PP GroupElementPtrLowLevel[PP, P], P any](out, pp *P, s [
 		PP(&res).Double(&res)
 		PP(&res).Double(&res)
 		w := (s[i] >> 4) & 0b1111
-		PP(&res).Add(&res, &precomputed[w])
+		var selected P
+		selectScalarMulWindow[PP](&selected, &precomputed, w)
+		PP(&res).Add(&res, &selected)
 
 		PP(&res).Double(&res)
 		PP(&res).Double(&res)
 		PP(&res).Double(&res)
 		PP(&res).Double(&res)
 		w = s[i] & 0b1111
-		PP(&res).Add(&res, &precomputed[w])
+		selectScalarMulWindow[PP](&selected, &precomputed, w)
+		PP(&res).Add(&res, &selected)
 	}
 
 	PP(out).Set(&res)
 }
 
-// MultiScalarMulLowLevel performs a Pippenger-style multi-scalar multiplication:
+func selectScalarMulWindow[PP GroupElementPtrLowLevel[PP, P], P any](out *P, precomputed *[16]P, w byte) {
+	PP(out).SetZero()
+	for i := range precomputed {
+		PP(out).Select(ct.Equal(w, byte(i)), out, &precomputed[i])
+	}
+}
+
+// MultiScalarMulLowLevel performs multi-scalar multiplication:
 //
 //	sum_i scalars[i] * points[i]
 //
-// using a fixed window size w.
+// This default path is constant-time with respect to scalar values: it uses
+// ScalarMulLowLevel for each scalar and never indexes or branches on scalar
+// bits. It assumes S.Bytes() is little-endian (LSB at index 0).
+func MultiScalarMulLowLevel[PP GroupElementPtrLowLevel[PP, P], P any](
+	out *P,
+	points []*P,
+	scalars [][]byte,
+) {
+	n := len(points)
+	if n == 0 {
+		panic("MultiScalarMul: no points")
+	}
+	if n != len(scalars) {
+		panic("MultiScalarMul: number of points and scalars must be equal")
+	}
+
+	var acc P
+	PP(&acc).SetZero()
+	for i := range n {
+		var term P
+		ScalarMulLowLevel[PP](&term, points[i], scalars[i])
+		PP(&acc).Add(&acc, &term)
+	}
+	PP(out).Set(&acc)
+}
+
+// MultiScalarMulLowLevelVartimePublic performs a Pippenger-style multi-scalar multiplication:
+//
+//	sum_i scalars[i] * points[i]
+//
+// using a fixed window size w. This function is variable-time and may branch
+// and index by scalar bits. It is suitable only when every scalar is public,
+// such as batch verification coefficients.
 //
 // It assumes S.Bytes() is little-endian (LSB at index 0).
-func MultiScalarMulLowLevel[PP GroupElementPtrLowLevel[PP, P], P any](
+func MultiScalarMulLowLevelVartimePublic[PP GroupElementPtrLowLevel[PP, P], P any](
 	out *P,
 	points []*P,
 	scalars [][]byte,
@@ -127,19 +169,14 @@ func MultiScalarMulLowLevel[PP GroupElementPtrLowLevel[PP, P], P any](
 		for range w {
 			PP(&acc).Add(&acc, &acc)
 		}
-		buckets := make([]PP, windowSize)
-		for i := range buckets {
-			var b P
-			PP(&b).SetZero()
-			buckets[i] = PP(&b)
-		}
+		buckets := make([]P, windowSize)
 		startBit := wIdx * w
 		for i := range n {
 			win := getWindow(scalarBytes[i], startBit)
 			if win == 0 {
 				continue
 			}
-			buckets[win].Add(buckets[win], points[i])
+			PP(&buckets[win]).Add(&buckets[win], points[i])
 		}
 
 		// Summation by running sum from highest bucket down.
@@ -148,8 +185,8 @@ func MultiScalarMulLowLevel[PP GroupElementPtrLowLevel[PP, P], P any](
 		var running P
 		PP(&running).SetZero()
 		for k := windowSize - 1; k > 0; k-- {
-			if isIdentity := buckets[k].IsZero(); isIdentity == ct.False {
-				PP(&running).Add(&running, buckets[k])
+			if isIdentity := PP(&buckets[k]).IsZero(); isIdentity == ct.False {
+				PP(&running).Add(&running, &buckets[k])
 			}
 			PP(&acc).Add(&acc, &running)
 		}

--- a/pkg/base/algebra/impl/mul_ct_test.go
+++ b/pkg/base/algebra/impl/mul_ct_test.go
@@ -1,0 +1,52 @@
+package impl_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestScalarMulLowLevelHasNoSecretIndexedTableLookup(t *testing.T) {
+	t.Parallel()
+
+	source := readMulSource(t)
+	require.NotContains(t, source, "precomputed[w]")
+}
+
+func TestMultiScalarMulLowLevelHasNoSecretWindowBuckets(t *testing.T) {
+	t.Parallel()
+
+	source := readMulSource(t)
+	secretBody := between(t, source, "func MultiScalarMulLowLevel[", "func MultiScalarMulLowLevelVartimePublic[")
+	require.NotContains(t, secretBody, "buckets[win]")
+	require.NotContains(t, secretBody, "if win == 0")
+	require.NotContains(t, secretBody, ".IsZero()")
+}
+
+func TestVariableTimeMSMIsPublicInputOnly(t *testing.T) {
+	t.Parallel()
+
+	source := readMulSource(t)
+	require.Contains(t, source, "MultiScalarMulLowLevelVartimePublic")
+	require.Contains(t, source, "suitable only when every scalar is public")
+}
+
+func readMulSource(t *testing.T) string {
+	t.Helper()
+
+	source, err := os.ReadFile("mul.go")
+	require.NoError(t, err)
+	return string(source)
+}
+
+func between(t *testing.T, source, start, end string) string {
+	t.Helper()
+
+	startIndex := strings.Index(source, start)
+	require.NotEqual(t, -1, startIndex)
+	endIndex := strings.Index(source[startIndex:], end)
+	require.NotEqual(t, -1, endIndex)
+	return source[startIndex : startIndex+endIndex]
+}

--- a/pkg/base/curves/edwards25519/impl/canonical_encoding_test.go
+++ b/pkg/base/curves/edwards25519/impl/canonical_encoding_test.go
@@ -1,0 +1,21 @@
+package impl_test
+
+import (
+	"testing"
+
+	edwards25519impl "github.com/bronlabs/bron-crypto/pkg/base/curves/edwards25519/impl"
+	curvetestutils "github.com/bronlabs/bron-crypto/pkg/base/curves/testutils"
+)
+
+func TestSetBytesRejectsNonCanonicalFieldEncodings(t *testing.T) {
+	t.Parallel()
+
+	curvetestutils.AssertCanonicalSetBytes(t, "Fp", edwards25519impl.FpModulus[:], func(data []byte) bool {
+		var f edwards25519impl.Fp
+		return f.SetBytes(data) == 1
+	})
+	curvetestutils.AssertCanonicalSetBytes(t, "Fq", edwards25519impl.FqModulus[:], func(data []byte) bool {
+		var f edwards25519impl.Fq
+		return f.SetBytes(data) == 1
+	})
+}

--- a/pkg/base/curves/edwards25519/impl/fp.go
+++ b/pkg/base/curves/edwards25519/impl/fp.go
@@ -260,12 +260,25 @@ func (f *Fp) SetLimbs(data []uint64) (ok ct.Bool) {
 
 // SetBytes sets the receiver from bytes.
 func (f *Fp) SetBytes(data []byte) (ok ct.Bool) {
-	if len(data) != int(FpBytes) || (data[FpBytes-1]&0x80 != 0) {
+	if len(data) != int(FpBytes) {
+		return 0
+	}
+	if isCanonicalFpBytes(data) == ct.False {
 		return 0
 	}
 
 	fiatFpFromBytes(&f.v, (*[FpBytes]uint8)(data))
 	return 1
+}
+
+func isCanonicalFpBytes(data []byte) ct.Bool {
+	var lt, gt ct.Choice
+	for i := FpBytes - 1; i >= 0; i-- {
+		undecided := (lt | gt).Not()
+		lt |= undecided & ct.Less(data[i], FpModulus[i])
+		gt |= undecided & ct.Greater(data[i], FpModulus[i])
+	}
+	return lt
 }
 
 // SetBytesWide sets the receiver from wide bytes.

--- a/pkg/base/curves/edwards25519/impl/fq.gen.go
+++ b/pkg/base/curves/edwards25519/impl/fq.gen.go
@@ -3,6 +3,7 @@
 package impl
 
 import (
+	"encoding/binary"
 	"encoding/hex"
 	"io"
 	"math/big"
@@ -55,12 +56,23 @@ func (f *Fq) SetUint64(v uint64) {
 }
 
 func (f *Fq) SetLimbs(data []uint64) (ok ct.Bool) {
-	fiatFqToMontgomery(&f.fiatFqMontgomeryDomainFieldElement, (*fiatFqNonMontgomeryDomainFieldElement)(data))
-	return 1
+	if len(data) != FqLimbs {
+		return 0
+	}
+
+	var byteData [FqBytes]byte
+	for i, limb := range data {
+		binary.LittleEndian.PutUint64(byteData[8*i:8*(i+1)], limb)
+	}
+
+	return f.SetBytes(byteData[:])
 }
 
 func (f *Fq) SetBytes(data []byte) (ok ct.Bool) {
 	if len(data) != FqBytes {
+		return 0
+	}
+	if isCanonicalFqBytes(data) == ct.False {
 		return 0
 	}
 
@@ -68,6 +80,16 @@ func (f *Fq) SetBytes(data []byte) (ok ct.Bool) {
 	fiatFqFromBytes((*[FqLimbs]uint64)(&nonMonty), (*[FqBytes]uint8)(data))
 	fiatFqToMontgomery(&f.fiatFqMontgomeryDomainFieldElement, &nonMonty)
 	return 1
+}
+
+func isCanonicalFqBytes(data []byte) ct.Bool {
+	var lt, gt ct.Choice
+	for i := FqBytes - 1; i >= 0; i-- {
+		undecided := (lt | gt).Not()
+		lt |= undecided & ct.Less(data[i], FqModulus[i])
+		gt |= undecided & ct.Greater(data[i], FqModulus[i])
+	}
+	return lt
 }
 
 func (f *Fq) SetBytesWide(data []byte) (ok ct.Bool) {
@@ -108,7 +130,7 @@ func (f *Fq) SetRandom(prng io.Reader) (ok ct.Bool) {
 }
 
 func (f *Fq) Select(choice ct.Choice, z, nz *Fq) {
-	fiatFqSelectznz((*[FqLimbs]uint64)(&f.fiatFqMontgomeryDomainFieldElement),fiatFqUint1(choice), (*[FqLimbs]uint64)(&z.fiatFqMontgomeryDomainFieldElement), (*[FqLimbs]uint64)(&nz.fiatFqMontgomeryDomainFieldElement))
+	fiatFqSelectznz((*[FqLimbs]uint64)(&f.fiatFqMontgomeryDomainFieldElement), fiatFqUint1(choice), (*[FqLimbs]uint64)(&z.fiatFqMontgomeryDomainFieldElement), (*[FqLimbs]uint64)(&nz.fiatFqMontgomeryDomainFieldElement))
 }
 
 func (f *Fq) Add(lhs, rhs *Fq) {

--- a/pkg/base/curves/k256/impl/canonical_encoding_test.go
+++ b/pkg/base/curves/k256/impl/canonical_encoding_test.go
@@ -1,0 +1,21 @@
+package impl_test
+
+import (
+	"testing"
+
+	k256impl "github.com/bronlabs/bron-crypto/pkg/base/curves/k256/impl"
+	curvetestutils "github.com/bronlabs/bron-crypto/pkg/base/curves/testutils"
+)
+
+func TestSetBytesRejectsNonCanonicalFieldEncodings(t *testing.T) {
+	t.Parallel()
+
+	curvetestutils.AssertCanonicalSetBytes(t, "Fp", k256impl.FpModulus[:], func(data []byte) bool {
+		var f k256impl.Fp
+		return f.SetBytes(data) == 1
+	})
+	curvetestutils.AssertCanonicalSetBytes(t, "Fq", k256impl.FqModulus[:], func(data []byte) bool {
+		var f k256impl.Fq
+		return f.SetBytes(data) == 1
+	})
+}

--- a/pkg/base/curves/k256/impl/fp.gen.go
+++ b/pkg/base/curves/k256/impl/fp.gen.go
@@ -3,6 +3,7 @@
 package impl
 
 import (
+	"encoding/binary"
 	"encoding/hex"
 	"io"
 	"math/big"
@@ -55,12 +56,23 @@ func (f *Fp) SetUint64(v uint64) {
 }
 
 func (f *Fp) SetLimbs(data []uint64) (ok ct.Bool) {
-	fiatFpToMontgomery(&f.fiatFpMontgomeryDomainFieldElement, (*fiatFpNonMontgomeryDomainFieldElement)(data))
-	return 1
+	if len(data) != FpLimbs {
+		return 0
+	}
+
+	var byteData [FpBytes]byte
+	for i, limb := range data {
+		binary.LittleEndian.PutUint64(byteData[8*i:8*(i+1)], limb)
+	}
+
+	return f.SetBytes(byteData[:])
 }
 
 func (f *Fp) SetBytes(data []byte) (ok ct.Bool) {
 	if len(data) != FpBytes {
+		return 0
+	}
+	if isCanonicalFpBytes(data) == ct.False {
 		return 0
 	}
 
@@ -68,6 +80,16 @@ func (f *Fp) SetBytes(data []byte) (ok ct.Bool) {
 	fiatFpFromBytes((*[FpLimbs]uint64)(&nonMonty), (*[FpBytes]uint8)(data))
 	fiatFpToMontgomery(&f.fiatFpMontgomeryDomainFieldElement, &nonMonty)
 	return 1
+}
+
+func isCanonicalFpBytes(data []byte) ct.Bool {
+	var lt, gt ct.Choice
+	for i := FpBytes - 1; i >= 0; i-- {
+		undecided := (lt | gt).Not()
+		lt |= undecided & ct.Less(data[i], FpModulus[i])
+		gt |= undecided & ct.Greater(data[i], FpModulus[i])
+	}
+	return lt
 }
 
 func (f *Fp) SetBytesWide(data []byte) (ok ct.Bool) {
@@ -108,7 +130,7 @@ func (f *Fp) SetRandom(prng io.Reader) (ok ct.Bool) {
 }
 
 func (f *Fp) Select(choice ct.Choice, z, nz *Fp) {
-	fiatFpSelectznz((*[FpLimbs]uint64)(&f.fiatFpMontgomeryDomainFieldElement),fiatFpUint1(choice), (*[FpLimbs]uint64)(&z.fiatFpMontgomeryDomainFieldElement), (*[FpLimbs]uint64)(&nz.fiatFpMontgomeryDomainFieldElement))
+	fiatFpSelectznz((*[FpLimbs]uint64)(&f.fiatFpMontgomeryDomainFieldElement), fiatFpUint1(choice), (*[FpLimbs]uint64)(&z.fiatFpMontgomeryDomainFieldElement), (*[FpLimbs]uint64)(&nz.fiatFpMontgomeryDomainFieldElement))
 }
 
 func (f *Fp) Add(lhs, rhs *Fp) {

--- a/pkg/base/curves/k256/impl/fq.gen.go
+++ b/pkg/base/curves/k256/impl/fq.gen.go
@@ -3,6 +3,7 @@
 package impl
 
 import (
+	"encoding/binary"
 	"encoding/hex"
 	"io"
 	"math/big"
@@ -55,12 +56,23 @@ func (f *Fq) SetUint64(v uint64) {
 }
 
 func (f *Fq) SetLimbs(data []uint64) (ok ct.Bool) {
-	fiatFqToMontgomery(&f.fiatFqMontgomeryDomainFieldElement, (*fiatFqNonMontgomeryDomainFieldElement)(data))
-	return 1
+	if len(data) != FqLimbs {
+		return 0
+	}
+
+	var byteData [FqBytes]byte
+	for i, limb := range data {
+		binary.LittleEndian.PutUint64(byteData[8*i:8*(i+1)], limb)
+	}
+
+	return f.SetBytes(byteData[:])
 }
 
 func (f *Fq) SetBytes(data []byte) (ok ct.Bool) {
 	if len(data) != FqBytes {
+		return 0
+	}
+	if isCanonicalFqBytes(data) == ct.False {
 		return 0
 	}
 
@@ -68,6 +80,16 @@ func (f *Fq) SetBytes(data []byte) (ok ct.Bool) {
 	fiatFqFromBytes((*[FqLimbs]uint64)(&nonMonty), (*[FqBytes]uint8)(data))
 	fiatFqToMontgomery(&f.fiatFqMontgomeryDomainFieldElement, &nonMonty)
 	return 1
+}
+
+func isCanonicalFqBytes(data []byte) ct.Bool {
+	var lt, gt ct.Choice
+	for i := FqBytes - 1; i >= 0; i-- {
+		undecided := (lt | gt).Not()
+		lt |= undecided & ct.Less(data[i], FqModulus[i])
+		gt |= undecided & ct.Greater(data[i], FqModulus[i])
+	}
+	return lt
 }
 
 func (f *Fq) SetBytesWide(data []byte) (ok ct.Bool) {
@@ -108,7 +130,7 @@ func (f *Fq) SetRandom(prng io.Reader) (ok ct.Bool) {
 }
 
 func (f *Fq) Select(choice ct.Choice, z, nz *Fq) {
-	fiatFqSelectznz((*[FqLimbs]uint64)(&f.fiatFqMontgomeryDomainFieldElement),fiatFqUint1(choice), (*[FqLimbs]uint64)(&z.fiatFqMontgomeryDomainFieldElement), (*[FqLimbs]uint64)(&nz.fiatFqMontgomeryDomainFieldElement))
+	fiatFqSelectznz((*[FqLimbs]uint64)(&f.fiatFqMontgomeryDomainFieldElement), fiatFqUint1(choice), (*[FqLimbs]uint64)(&z.fiatFqMontgomeryDomainFieldElement), (*[FqLimbs]uint64)(&nz.fiatFqMontgomeryDomainFieldElement))
 }
 
 func (f *Fq) Add(lhs, rhs *Fq) {

--- a/pkg/base/curves/p256/impl/canonical_encoding_test.go
+++ b/pkg/base/curves/p256/impl/canonical_encoding_test.go
@@ -1,0 +1,21 @@
+package impl_test
+
+import (
+	"testing"
+
+	p256impl "github.com/bronlabs/bron-crypto/pkg/base/curves/p256/impl"
+	curvetestutils "github.com/bronlabs/bron-crypto/pkg/base/curves/testutils"
+)
+
+func TestSetBytesRejectsNonCanonicalFieldEncodings(t *testing.T) {
+	t.Parallel()
+
+	curvetestutils.AssertCanonicalSetBytes(t, "Fp", p256impl.FpModulus[:], func(data []byte) bool {
+		var f p256impl.Fp
+		return f.SetBytes(data) == 1
+	})
+	curvetestutils.AssertCanonicalSetBytes(t, "Fq", p256impl.FqModulus[:], func(data []byte) bool {
+		var f p256impl.Fq
+		return f.SetBytes(data) == 1
+	})
+}

--- a/pkg/base/curves/p256/impl/fp.gen.go
+++ b/pkg/base/curves/p256/impl/fp.gen.go
@@ -3,6 +3,7 @@
 package impl
 
 import (
+	"encoding/binary"
 	"encoding/hex"
 	"io"
 	"math/big"
@@ -55,12 +56,23 @@ func (f *Fp) SetUint64(v uint64) {
 }
 
 func (f *Fp) SetLimbs(data []uint64) (ok ct.Bool) {
-	fiatFpToMontgomery(&f.fiatFpMontgomeryDomainFieldElement, (*fiatFpNonMontgomeryDomainFieldElement)(data))
-	return 1
+	if len(data) != FpLimbs {
+		return 0
+	}
+
+	var byteData [FpBytes]byte
+	for i, limb := range data {
+		binary.LittleEndian.PutUint64(byteData[8*i:8*(i+1)], limb)
+	}
+
+	return f.SetBytes(byteData[:])
 }
 
 func (f *Fp) SetBytes(data []byte) (ok ct.Bool) {
 	if len(data) != FpBytes {
+		return 0
+	}
+	if isCanonicalFpBytes(data) == ct.False {
 		return 0
 	}
 
@@ -68,6 +80,16 @@ func (f *Fp) SetBytes(data []byte) (ok ct.Bool) {
 	fiatFpFromBytes((*[FpLimbs]uint64)(&nonMonty), (*[FpBytes]uint8)(data))
 	fiatFpToMontgomery(&f.fiatFpMontgomeryDomainFieldElement, &nonMonty)
 	return 1
+}
+
+func isCanonicalFpBytes(data []byte) ct.Bool {
+	var lt, gt ct.Choice
+	for i := FpBytes - 1; i >= 0; i-- {
+		undecided := (lt | gt).Not()
+		lt |= undecided & ct.Less(data[i], FpModulus[i])
+		gt |= undecided & ct.Greater(data[i], FpModulus[i])
+	}
+	return lt
 }
 
 func (f *Fp) SetBytesWide(data []byte) (ok ct.Bool) {
@@ -108,7 +130,7 @@ func (f *Fp) SetRandom(prng io.Reader) (ok ct.Bool) {
 }
 
 func (f *Fp) Select(choice ct.Choice, z, nz *Fp) {
-	fiatFpSelectznz((*[FpLimbs]uint64)(&f.fiatFpMontgomeryDomainFieldElement),fiatFpUint1(choice), (*[FpLimbs]uint64)(&z.fiatFpMontgomeryDomainFieldElement), (*[FpLimbs]uint64)(&nz.fiatFpMontgomeryDomainFieldElement))
+	fiatFpSelectznz((*[FpLimbs]uint64)(&f.fiatFpMontgomeryDomainFieldElement), fiatFpUint1(choice), (*[FpLimbs]uint64)(&z.fiatFpMontgomeryDomainFieldElement), (*[FpLimbs]uint64)(&nz.fiatFpMontgomeryDomainFieldElement))
 }
 
 func (f *Fp) Add(lhs, rhs *Fp) {

--- a/pkg/base/curves/p256/impl/fq.gen.go
+++ b/pkg/base/curves/p256/impl/fq.gen.go
@@ -3,6 +3,7 @@
 package impl
 
 import (
+	"encoding/binary"
 	"encoding/hex"
 	"io"
 	"math/big"
@@ -55,12 +56,23 @@ func (f *Fq) SetUint64(v uint64) {
 }
 
 func (f *Fq) SetLimbs(data []uint64) (ok ct.Bool) {
-	fiatFqToMontgomery(&f.fiatFqMontgomeryDomainFieldElement, (*fiatFqNonMontgomeryDomainFieldElement)(data))
-	return 1
+	if len(data) != FqLimbs {
+		return 0
+	}
+
+	var byteData [FqBytes]byte
+	for i, limb := range data {
+		binary.LittleEndian.PutUint64(byteData[8*i:8*(i+1)], limb)
+	}
+
+	return f.SetBytes(byteData[:])
 }
 
 func (f *Fq) SetBytes(data []byte) (ok ct.Bool) {
 	if len(data) != FqBytes {
+		return 0
+	}
+	if isCanonicalFqBytes(data) == ct.False {
 		return 0
 	}
 
@@ -68,6 +80,16 @@ func (f *Fq) SetBytes(data []byte) (ok ct.Bool) {
 	fiatFqFromBytes((*[FqLimbs]uint64)(&nonMonty), (*[FqBytes]uint8)(data))
 	fiatFqToMontgomery(&f.fiatFqMontgomeryDomainFieldElement, &nonMonty)
 	return 1
+}
+
+func isCanonicalFqBytes(data []byte) ct.Bool {
+	var lt, gt ct.Choice
+	for i := FqBytes - 1; i >= 0; i-- {
+		undecided := (lt | gt).Not()
+		lt |= undecided & ct.Less(data[i], FqModulus[i])
+		gt |= undecided & ct.Greater(data[i], FqModulus[i])
+	}
+	return lt
 }
 
 func (f *Fq) SetBytesWide(data []byte) (ok ct.Bool) {
@@ -108,7 +130,7 @@ func (f *Fq) SetRandom(prng io.Reader) (ok ct.Bool) {
 }
 
 func (f *Fq) Select(choice ct.Choice, z, nz *Fq) {
-	fiatFqSelectznz((*[FqLimbs]uint64)(&f.fiatFqMontgomeryDomainFieldElement),fiatFqUint1(choice), (*[FqLimbs]uint64)(&z.fiatFqMontgomeryDomainFieldElement), (*[FqLimbs]uint64)(&nz.fiatFqMontgomeryDomainFieldElement))
+	fiatFqSelectznz((*[FqLimbs]uint64)(&f.fiatFqMontgomeryDomainFieldElement), fiatFqUint1(choice), (*[FqLimbs]uint64)(&z.fiatFqMontgomeryDomainFieldElement), (*[FqLimbs]uint64)(&nz.fiatFqMontgomeryDomainFieldElement))
 }
 
 func (f *Fq) Add(lhs, rhs *Fq) {

--- a/pkg/base/curves/pairable/bls12381/impl/canonical_encoding_test.go
+++ b/pkg/base/curves/pairable/bls12381/impl/canonical_encoding_test.go
@@ -1,0 +1,21 @@
+package impl_test
+
+import (
+	"testing"
+
+	bls12381impl "github.com/bronlabs/bron-crypto/pkg/base/curves/pairable/bls12381/impl"
+	curvetestutils "github.com/bronlabs/bron-crypto/pkg/base/curves/testutils"
+)
+
+func TestSetBytesRejectsNonCanonicalFieldEncodings(t *testing.T) {
+	t.Parallel()
+
+	curvetestutils.AssertCanonicalSetBytes(t, "Fp", bls12381impl.FpModulus[:], func(data []byte) bool {
+		var f bls12381impl.Fp
+		return f.SetBytes(data) == 1
+	})
+	curvetestutils.AssertCanonicalSetBytes(t, "Fq", bls12381impl.FqModulus[:], func(data []byte) bool {
+		var f bls12381impl.Fq
+		return f.SetBytes(data) == 1
+	})
+}

--- a/pkg/base/curves/pairable/bls12381/impl/fp.gen.go
+++ b/pkg/base/curves/pairable/bls12381/impl/fp.gen.go
@@ -3,6 +3,7 @@
 package impl
 
 import (
+	"encoding/binary"
 	"encoding/hex"
 	"io"
 	"math/big"
@@ -55,12 +56,23 @@ func (f *Fp) SetUint64(v uint64) {
 }
 
 func (f *Fp) SetLimbs(data []uint64) (ok ct.Bool) {
-	fiatFpToMontgomery(&f.fiatFpMontgomeryDomainFieldElement, (*fiatFpNonMontgomeryDomainFieldElement)(data))
-	return 1
+	if len(data) != FpLimbs {
+		return 0
+	}
+
+	var byteData [FpBytes]byte
+	for i, limb := range data {
+		binary.LittleEndian.PutUint64(byteData[8*i:8*(i+1)], limb)
+	}
+
+	return f.SetBytes(byteData[:])
 }
 
 func (f *Fp) SetBytes(data []byte) (ok ct.Bool) {
 	if len(data) != FpBytes {
+		return 0
+	}
+	if isCanonicalFpBytes(data) == ct.False {
 		return 0
 	}
 
@@ -68,6 +80,16 @@ func (f *Fp) SetBytes(data []byte) (ok ct.Bool) {
 	fiatFpFromBytes((*[FpLimbs]uint64)(&nonMonty), (*[FpBytes]uint8)(data))
 	fiatFpToMontgomery(&f.fiatFpMontgomeryDomainFieldElement, &nonMonty)
 	return 1
+}
+
+func isCanonicalFpBytes(data []byte) ct.Bool {
+	var lt, gt ct.Choice
+	for i := FpBytes - 1; i >= 0; i-- {
+		undecided := (lt | gt).Not()
+		lt |= undecided & ct.Less(data[i], FpModulus[i])
+		gt |= undecided & ct.Greater(data[i], FpModulus[i])
+	}
+	return lt
 }
 
 func (f *Fp) SetBytesWide(data []byte) (ok ct.Bool) {
@@ -108,7 +130,7 @@ func (f *Fp) SetRandom(prng io.Reader) (ok ct.Bool) {
 }
 
 func (f *Fp) Select(choice ct.Choice, z, nz *Fp) {
-	fiatFpSelectznz((*[FpLimbs]uint64)(&f.fiatFpMontgomeryDomainFieldElement),fiatFpUint1(choice), (*[FpLimbs]uint64)(&z.fiatFpMontgomeryDomainFieldElement), (*[FpLimbs]uint64)(&nz.fiatFpMontgomeryDomainFieldElement))
+	fiatFpSelectznz((*[FpLimbs]uint64)(&f.fiatFpMontgomeryDomainFieldElement), fiatFpUint1(choice), (*[FpLimbs]uint64)(&z.fiatFpMontgomeryDomainFieldElement), (*[FpLimbs]uint64)(&nz.fiatFpMontgomeryDomainFieldElement))
 }
 
 func (f *Fp) Add(lhs, rhs *Fp) {

--- a/pkg/base/curves/pairable/bls12381/impl/fq.gen.go
+++ b/pkg/base/curves/pairable/bls12381/impl/fq.gen.go
@@ -3,6 +3,7 @@
 package impl
 
 import (
+	"encoding/binary"
 	"encoding/hex"
 	"io"
 	"math/big"
@@ -55,12 +56,23 @@ func (f *Fq) SetUint64(v uint64) {
 }
 
 func (f *Fq) SetLimbs(data []uint64) (ok ct.Bool) {
-	fiatFqToMontgomery(&f.fiatFqMontgomeryDomainFieldElement, (*fiatFqNonMontgomeryDomainFieldElement)(data))
-	return 1
+	if len(data) != FqLimbs {
+		return 0
+	}
+
+	var byteData [FqBytes]byte
+	for i, limb := range data {
+		binary.LittleEndian.PutUint64(byteData[8*i:8*(i+1)], limb)
+	}
+
+	return f.SetBytes(byteData[:])
 }
 
 func (f *Fq) SetBytes(data []byte) (ok ct.Bool) {
 	if len(data) != FqBytes {
+		return 0
+	}
+	if isCanonicalFqBytes(data) == ct.False {
 		return 0
 	}
 
@@ -68,6 +80,16 @@ func (f *Fq) SetBytes(data []byte) (ok ct.Bool) {
 	fiatFqFromBytes((*[FqLimbs]uint64)(&nonMonty), (*[FqBytes]uint8)(data))
 	fiatFqToMontgomery(&f.fiatFqMontgomeryDomainFieldElement, &nonMonty)
 	return 1
+}
+
+func isCanonicalFqBytes(data []byte) ct.Bool {
+	var lt, gt ct.Choice
+	for i := FqBytes - 1; i >= 0; i-- {
+		undecided := (lt | gt).Not()
+		lt |= undecided & ct.Less(data[i], FqModulus[i])
+		gt |= undecided & ct.Greater(data[i], FqModulus[i])
+	}
+	return lt
 }
 
 func (f *Fq) SetBytesWide(data []byte) (ok ct.Bool) {
@@ -108,7 +130,7 @@ func (f *Fq) SetRandom(prng io.Reader) (ok ct.Bool) {
 }
 
 func (f *Fq) Select(choice ct.Choice, z, nz *Fq) {
-	fiatFqSelectznz((*[FqLimbs]uint64)(&f.fiatFqMontgomeryDomainFieldElement),fiatFqUint1(choice), (*[FqLimbs]uint64)(&z.fiatFqMontgomeryDomainFieldElement), (*[FqLimbs]uint64)(&nz.fiatFqMontgomeryDomainFieldElement))
+	fiatFqSelectznz((*[FqLimbs]uint64)(&f.fiatFqMontgomeryDomainFieldElement), fiatFqUint1(choice), (*[FqLimbs]uint64)(&z.fiatFqMontgomeryDomainFieldElement), (*[FqLimbs]uint64)(&nz.fiatFqMontgomeryDomainFieldElement))
 }
 
 func (f *Fq) Add(lhs, rhs *Fq) {

--- a/pkg/base/curves/pasta/impl/canonical_encoding_test.go
+++ b/pkg/base/curves/pasta/impl/canonical_encoding_test.go
@@ -1,0 +1,21 @@
+package impl_test
+
+import (
+	"testing"
+
+	pastaimpl "github.com/bronlabs/bron-crypto/pkg/base/curves/pasta/impl"
+	curvetestutils "github.com/bronlabs/bron-crypto/pkg/base/curves/testutils"
+)
+
+func TestSetBytesRejectsNonCanonicalFieldEncodings(t *testing.T) {
+	t.Parallel()
+
+	curvetestutils.AssertCanonicalSetBytes(t, "Fp", pastaimpl.FpModulus[:], func(data []byte) bool {
+		var f pastaimpl.Fp
+		return f.SetBytes(data) == 1
+	})
+	curvetestutils.AssertCanonicalSetBytes(t, "Fq", pastaimpl.FqModulus[:], func(data []byte) bool {
+		var f pastaimpl.Fq
+		return f.SetBytes(data) == 1
+	})
+}

--- a/pkg/base/curves/pasta/impl/fp.gen.go
+++ b/pkg/base/curves/pasta/impl/fp.gen.go
@@ -3,6 +3,7 @@
 package impl
 
 import (
+	"encoding/binary"
 	"encoding/hex"
 	"io"
 	"math/big"
@@ -55,12 +56,23 @@ func (f *Fp) SetUint64(v uint64) {
 }
 
 func (f *Fp) SetLimbs(data []uint64) (ok ct.Bool) {
-	fiatFpToMontgomery(&f.fiatFpMontgomeryDomainFieldElement, (*fiatFpNonMontgomeryDomainFieldElement)(data))
-	return 1
+	if len(data) != FpLimbs {
+		return 0
+	}
+
+	var byteData [FpBytes]byte
+	for i, limb := range data {
+		binary.LittleEndian.PutUint64(byteData[8*i:8*(i+1)], limb)
+	}
+
+	return f.SetBytes(byteData[:])
 }
 
 func (f *Fp) SetBytes(data []byte) (ok ct.Bool) {
 	if len(data) != FpBytes {
+		return 0
+	}
+	if isCanonicalFpBytes(data) == ct.False {
 		return 0
 	}
 
@@ -68,6 +80,16 @@ func (f *Fp) SetBytes(data []byte) (ok ct.Bool) {
 	fiatFpFromBytes((*[FpLimbs]uint64)(&nonMonty), (*[FpBytes]uint8)(data))
 	fiatFpToMontgomery(&f.fiatFpMontgomeryDomainFieldElement, &nonMonty)
 	return 1
+}
+
+func isCanonicalFpBytes(data []byte) ct.Bool {
+	var lt, gt ct.Choice
+	for i := FpBytes - 1; i >= 0; i-- {
+		undecided := (lt | gt).Not()
+		lt |= undecided & ct.Less(data[i], FpModulus[i])
+		gt |= undecided & ct.Greater(data[i], FpModulus[i])
+	}
+	return lt
 }
 
 func (f *Fp) SetBytesWide(data []byte) (ok ct.Bool) {
@@ -108,7 +130,7 @@ func (f *Fp) SetRandom(prng io.Reader) (ok ct.Bool) {
 }
 
 func (f *Fp) Select(choice ct.Choice, z, nz *Fp) {
-	fiatFpSelectznz((*[FpLimbs]uint64)(&f.fiatFpMontgomeryDomainFieldElement),fiatFpUint1(choice), (*[FpLimbs]uint64)(&z.fiatFpMontgomeryDomainFieldElement), (*[FpLimbs]uint64)(&nz.fiatFpMontgomeryDomainFieldElement))
+	fiatFpSelectznz((*[FpLimbs]uint64)(&f.fiatFpMontgomeryDomainFieldElement), fiatFpUint1(choice), (*[FpLimbs]uint64)(&z.fiatFpMontgomeryDomainFieldElement), (*[FpLimbs]uint64)(&nz.fiatFpMontgomeryDomainFieldElement))
 }
 
 func (f *Fp) Add(lhs, rhs *Fp) {

--- a/pkg/base/curves/pasta/impl/fq.gen.go
+++ b/pkg/base/curves/pasta/impl/fq.gen.go
@@ -3,6 +3,7 @@
 package impl
 
 import (
+	"encoding/binary"
 	"encoding/hex"
 	"io"
 	"math/big"
@@ -55,12 +56,23 @@ func (f *Fq) SetUint64(v uint64) {
 }
 
 func (f *Fq) SetLimbs(data []uint64) (ok ct.Bool) {
-	fiatFqToMontgomery(&f.fiatFqMontgomeryDomainFieldElement, (*fiatFqNonMontgomeryDomainFieldElement)(data))
-	return 1
+	if len(data) != FqLimbs {
+		return 0
+	}
+
+	var byteData [FqBytes]byte
+	for i, limb := range data {
+		binary.LittleEndian.PutUint64(byteData[8*i:8*(i+1)], limb)
+	}
+
+	return f.SetBytes(byteData[:])
 }
 
 func (f *Fq) SetBytes(data []byte) (ok ct.Bool) {
 	if len(data) != FqBytes {
+		return 0
+	}
+	if isCanonicalFqBytes(data) == ct.False {
 		return 0
 	}
 
@@ -68,6 +80,16 @@ func (f *Fq) SetBytes(data []byte) (ok ct.Bool) {
 	fiatFqFromBytes((*[FqLimbs]uint64)(&nonMonty), (*[FqBytes]uint8)(data))
 	fiatFqToMontgomery(&f.fiatFqMontgomeryDomainFieldElement, &nonMonty)
 	return 1
+}
+
+func isCanonicalFqBytes(data []byte) ct.Bool {
+	var lt, gt ct.Choice
+	for i := FqBytes - 1; i >= 0; i-- {
+		undecided := (lt | gt).Not()
+		lt |= undecided & ct.Less(data[i], FqModulus[i])
+		gt |= undecided & ct.Greater(data[i], FqModulus[i])
+	}
+	return lt
 }
 
 func (f *Fq) SetBytesWide(data []byte) (ok ct.Bool) {
@@ -108,7 +130,7 @@ func (f *Fq) SetRandom(prng io.Reader) (ok ct.Bool) {
 }
 
 func (f *Fq) Select(choice ct.Choice, z, nz *Fq) {
-	fiatFqSelectznz((*[FqLimbs]uint64)(&f.fiatFqMontgomeryDomainFieldElement),fiatFqUint1(choice), (*[FqLimbs]uint64)(&z.fiatFqMontgomeryDomainFieldElement), (*[FqLimbs]uint64)(&nz.fiatFqMontgomeryDomainFieldElement))
+	fiatFqSelectznz((*[FqLimbs]uint64)(&f.fiatFqMontgomeryDomainFieldElement), fiatFqUint1(choice), (*[FqLimbs]uint64)(&z.fiatFqMontgomeryDomainFieldElement), (*[FqLimbs]uint64)(&nz.fiatFqMontgomeryDomainFieldElement))
 }
 
 func (f *Fq) Add(lhs, rhs *Fq) {

--- a/pkg/base/curves/testutils/canonical.go
+++ b/pkg/base/curves/testutils/canonical.go
@@ -1,0 +1,42 @@
+package testutils
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// AssertCanonicalSetBytes checks that SetBytes accepts canonical encodings and rejects values >= modulus.
+func AssertCanonicalSetBytes(t *testing.T, name string, modulus []byte, set func([]byte) bool) {
+	t.Helper()
+
+	require.True(t, set(make([]byte, len(modulus))), "%s zero must be canonical", name)
+	require.True(t, set(subOneLE(modulus)), "%s modulus-1 must be canonical", name)
+	require.False(t, set(append([]byte(nil), modulus...)), "%s modulus must be rejected", name)
+	require.False(t, set(addOneLE(modulus)), "%s modulus+1 must be rejected", name)
+	require.False(t, set(bytes.Repeat([]byte{0xff}, len(modulus))), "%s all-ones must be rejected", name)
+}
+
+func subOneLE(in []byte) []byte {
+	out := append([]byte(nil), in...)
+	for i := range out {
+		if out[i] != 0 {
+			out[i]--
+			return out
+		}
+		out[i] = 0xff
+	}
+	return out
+}
+
+func addOneLE(in []byte) []byte {
+	out := append([]byte(nil), in...)
+	for i := range out {
+		out[i]++
+		if out[i] != 0 {
+			return out
+		}
+	}
+	return out
+}

--- a/pkg/base/nt/numct/modulus_cgo.go
+++ b/pkg/base/nt/numct/modulus_cgo.go
@@ -73,9 +73,6 @@ func (m *Modulus) cacheMont() {
 }
 
 func (m *Modulus) ensureMont() {
-	if m.mont != nil {
-		return
-	}
 	m.once.Do(func() { m.cacheMont() })
 }
 

--- a/pkg/base/prng/pcg/doc.go
+++ b/pkg/base/prng/pcg/doc.go
@@ -1,3 +1,6 @@
-// Package pcg provides a seedable PCG-based PRNG for tests and non-cryptographic
-// randomness.
+// Package pcg provides a seedable PCG-based PRNG for tests and non-cryptographic randomness.
+//
+// Security warning: PCG is not cryptographically secure. Production code must
+// use a CSPRNG or accept an explicit cryptographically secure io.Reader instead.
+// CI blocks imports of this package outside tests, test utilities, and tools.
 package pcg

--- a/pkg/base/prng/pcg/pcg.go
+++ b/pkg/base/prng/pcg/pcg.go
@@ -3,6 +3,7 @@ package pcg
 import (
 	"encoding/binary"
 	mrand "math/rand/v2"
+	"sync"
 
 	"github.com/bronlabs/errs-go/errs"
 
@@ -14,26 +15,33 @@ var (
 	ErrInvalidSaltLength = errs.New("salt length is not 8 bytes")
 )
 
+// Pcg is a non-cryptographic seedable PCG PRNG for tests.
 type Pcg struct {
-	v *mrand.PCG
+	mu sync.Mutex
+	v  *mrand.PCG
 }
 
 // New creates a new PCG PRNG seeded with the given seed and salt.
 func New(seed, salt uint64) *Pcg {
 	return &Pcg{
-		v: mrand.NewPCG(seed, salt),
+		mu: sync.Mutex{},
+		v:  mrand.NewPCG(seed, salt),
 	}
 }
 
 // NewRandomised creates a new PCG PRNG with random seed and salt.
 func NewRandomised() *Pcg {
 	return &Pcg{
-		v: mrand.NewPCG(mrand.Uint64(), mrand.Uint64()), //nolint:gosec // weak prng is intentional.
+		mu: sync.Mutex{},
+		v:  mrand.NewPCG(mrand.Uint64(), mrand.Uint64()), //nolint:gosec // weak prng is intentional.
 	}
 }
 
 // Read fills the provided byte slice p with random bytes.
 func (r *Pcg) Read(p []byte) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	n := len(p)
 	for len(p) >= 8 {
 		binary.LittleEndian.PutUint64(p[:8], r.v.Uint64())
@@ -54,6 +62,8 @@ func (r *Pcg) Seed(seed, salt []byte) error {
 	}
 	seedUint64 := binary.LittleEndian.Uint64(seed)
 	saltUint64 := binary.LittleEndian.Uint64(salt)
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.v.Seed(seedUint64, saltUint64)
 	return nil
 }

--- a/pkg/base/utils/common.go
+++ b/pkg/base/utils/common.go
@@ -26,7 +26,7 @@ func IsNil[T any](v T) bool {
 		return true
 	}
 	switch val.Kind() { //nolint:exhaustive // only types that can be nil are checked
-	case reflect.Ptr, reflect.Interface, reflect.Map, reflect.Slice, reflect.Chan, reflect.Func:
+	case reflect.Pointer, reflect.Interface, reflect.Map, reflect.Slice, reflect.Chan, reflect.Func:
 		return val.IsNil()
 	default:
 		return false

--- a/pkg/hashing/poseidon/poseidon.go
+++ b/pkg/hashing/poseidon/poseidon.go
@@ -92,7 +92,7 @@ func (p *Poseidon) CloneHasher() *Poseidon {
 	}
 }
 
-// Write implements io.Writer by converting bytes to field elements and hashing them.
+// Write implements io.Writer by reducing fixed-width byte chunks to field elements and hashing them.
 // Note: The sponge absorbs bytes in rate-sized blocks, the callers must pad to full blocks before passing,
 // and callers who need injective variable-length hashing must perform their own framing, length encoding,
 // or domain separation before absorption, hence the data length must be a multiple of (32 * rate) bytes.
@@ -104,7 +104,7 @@ func (p *Poseidon) Write(data []byte) (n int, err error) {
 	var elems []*pasta.PallasBaseFieldElement
 	for i := range len(data) / pastaImpl.FpBytes {
 		bytes := data[pastaImpl.FpBytes*i : pastaImpl.FpBytes*(i+1)]
-		fe, err := pasta.NewPallasBaseField().FromBytes(bytes)
+		fe, err := pasta.NewPallasBaseField().FromBytesBEReduce(bytes)
 		if err != nil {
 			return 0, errs.Wrap(err).WithMessage("cannot create Pallas base field element")
 		}

--- a/pkg/mpc/rvole/softspoken/participant.go
+++ b/pkg/mpc/rvole/softspoken/participant.go
@@ -82,15 +82,23 @@ func newParticipant[P curves.Point[P, B, S], B algebra.FieldElement[B], S algebr
 	}, nil
 }
 
-// NewAlice returns a new Alice participant.
-func NewAlice[P curves.Point[P, B, S], B algebra.FieldElement[B], S algebra.PrimeFieldElement[S]](ctx *session.Context, suite *Suite[P, B, S], seeds *vsot.ReceiverOutput, prng io.Reader) (*Alice[P, B, S], error) {
-	p, err := newParticipant(ctx, suite, prng, 2)
+func newParticipantAndSoftspokenSuite[P curves.Point[P, B, S], B algebra.FieldElement[B], S algebra.PrimeFieldElement[S]](ctx *session.Context, suite *Suite[P, B, S], prng io.Reader, initialRound int) (*participant[P, B, S], *softspoken.Suite, error) {
+	p, err := newParticipant(ctx, suite, prng, initialRound)
 	if err != nil {
-		return nil, errs.Wrap(err).WithMessage("could not create participant / gadget vector")
+		return nil, nil, errs.Wrap(err).WithMessage("could not create participant / gadget vector")
 	}
 	softspokenSuite, err := softspoken.NewSuite(p.xi, suite.l+p.rho, suite.hashFunc)
 	if err != nil {
-		return nil, errs.Wrap(err).WithMessage("could not create softspoken suite")
+		return nil, nil, errs.Wrap(err).WithMessage("could not create softspoken suite")
+	}
+	return p, softspokenSuite, nil
+}
+
+// NewAlice returns a new Alice participant.
+func NewAlice[P curves.Point[P, B, S], B algebra.FieldElement[B], S algebra.PrimeFieldElement[S]](ctx *session.Context, suite *Suite[P, B, S], seeds *vsot.ReceiverOutput, prng io.Reader) (*Alice[P, B, S], error) {
+	p, softspokenSuite, err := newParticipantAndSoftspokenSuite(ctx, suite, prng, 2)
+	if err != nil {
+		return nil, err
 	}
 
 	sender, err := softspoken.NewSender(ctx, seeds, softspokenSuite, prng)
@@ -113,13 +121,9 @@ func NewAlice[P curves.Point[P, B, S], B algebra.FieldElement[B], S algebra.Prim
 
 // NewBob returns a new Bob participant.
 func NewBob[P curves.Point[P, B, S], B algebra.FieldElement[B], S algebra.PrimeFieldElement[S]](ctx *session.Context, suite *Suite[P, B, S], seeds *vsot.SenderOutput, prng io.Reader) (*Bob[P, B, S], error) {
-	p, err := newParticipant(ctx, suite, prng, 1)
+	p, softspokenSuite, err := newParticipantAndSoftspokenSuite(ctx, suite, prng, 1)
 	if err != nil {
-		return nil, errs.Wrap(err).WithMessage("could not create participant / gadget vector")
-	}
-	softspokenSuite, err := softspoken.NewSuite(p.xi, suite.l+p.rho, suite.hashFunc)
-	if err != nil {
-		return nil, errs.Wrap(err).WithMessage("could not create softspoken suite")
+		return nil, err
 	}
 
 	receiver, err := softspoken.NewReceiver(ctx, seeds, softspokenSuite, prng)

--- a/pkg/mpc/signatures/bls/boldyreva02/signing/aggregator.go
+++ b/pkg/mpc/signatures/bls/boldyreva02/signing/aggregator.go
@@ -50,21 +50,21 @@ func NewShortKeyAggregator[
 	publicMaterial *boldyreva02.PublicMaterial[P1, FE1, P2, FE2, E, S],
 	rogueKeyAlg bls.RogueKeyPreventionAlgorithm,
 ) (*Aggregator[P1, FE1, P2, FE2, E, S], error) {
-	if curveFamily == nil {
-		return nil, ErrInvalidArgument.WithMessage("curveFamily is nil")
-	}
-	if publicMaterial == nil {
-		return nil, ErrInvalidArgument.WithMessage("publicMaterial is nil")
-	}
-	scheme, err := bls.NewShortKeyScheme(curveFamily, bls.POP)
-	if err != nil {
-		return nil, errs.Wrap(err).WithMessage("failed to create BLS short key scheme")
-	}
-	out, err := newAggregator(scheme, publicMaterial, curveFamily.TwistedSubGroup(), rogueKeyAlg, bls.ShortKey)
-	if err != nil {
-		return nil, errs.Wrap(err).WithMessage("failed to create short key aggregator")
-	}
-	return out, nil
+	return newVariantAggregator[
+		P1, FE1, P2, FE2, E, S,
+		P1, FE1, P2, FE2,
+	](
+		curveFamily,
+		publicMaterial,
+		rogueKeyAlg,
+		bls.NewShortKeyScheme[P1, FE1, P2, FE2, E, S],
+		func(curveFamily curves.PairingFriendlyFamily[P1, FE1, P2, FE2, E, S]) curves.PairingFriendlyCurve[P2, FE2, P1, FE1, E, S] {
+			return curveFamily.TwistedSubGroup()
+		},
+		bls.ShortKey,
+		"failed to create BLS short key scheme",
+		"failed to create short key aggregator",
+	)
 }
 
 // NewLongKeyAggregator creates a new Aggregator for the long key variant of BLS signatures.
@@ -78,19 +78,52 @@ func NewLongKeyAggregator[
 	publicMaterial *boldyreva02.PublicMaterial[P2, FE2, P1, FE1, E, S],
 	rogueKeyAlg bls.RogueKeyPreventionAlgorithm,
 ) (*Aggregator[P2, FE2, P1, FE1, E, S], error) {
+	return newVariantAggregator[
+		P1, FE1, P2, FE2, E, S,
+		P2, FE2, P1, FE1,
+	](
+		curveFamily,
+		publicMaterial,
+		rogueKeyAlg,
+		bls.NewLongKeyScheme[P1, FE1, P2, FE2, E, S],
+		func(curveFamily curves.PairingFriendlyFamily[P1, FE1, P2, FE2, E, S]) curves.PairingFriendlyCurve[P1, FE1, P2, FE2, E, S] {
+			return curveFamily.SourceSubGroup()
+		},
+		bls.LongKey,
+		"failed to create BLS long key scheme",
+		"failed to create long key aggregator",
+	)
+}
+
+func newVariantAggregator[
+	P1 curves.PairingFriendlyPoint[P1, FE1, P2, FE2, E, S], FE1 algebra.FieldElement[FE1],
+	P2 curves.PairingFriendlyPoint[P2, FE2, P1, FE1, E, S], FE2 algebra.FieldElement[FE2],
+	E algebra.MultiplicativeGroupElement[E], S algebra.PrimeFieldElement[S],
+	PK curves.PairingFriendlyPoint[PK, PKFE, SG, SGFE, E, S], PKFE algebra.FieldElement[PKFE],
+	SG curves.PairingFriendlyPoint[SG, SGFE, PK, PKFE, E, S], SGFE algebra.FieldElement[SGFE],
+](
+	curveFamily curves.PairingFriendlyFamily[P1, FE1, P2, FE2, E, S],
+	publicMaterial *boldyreva02.PublicMaterial[PK, PKFE, SG, SGFE, E, S],
+	rogueKeyAlg bls.RogueKeyPreventionAlgorithm,
+	newScheme func(curves.PairingFriendlyFamily[P1, FE1, P2, FE2, E, S], bls.RogueKeyPreventionAlgorithm) (*bls.Scheme[PK, PKFE, SG, SGFE, E, S], error),
+	signatureSubGroup func(curves.PairingFriendlyFamily[P1, FE1, P2, FE2, E, S]) curves.PairingFriendlyCurve[SG, SGFE, PK, PKFE, E, S],
+	variant bls.Variant,
+	schemeErrorMessage string,
+	aggregatorErrorMessage string,
+) (*Aggregator[PK, PKFE, SG, SGFE, E, S], error) {
 	if curveFamily == nil {
 		return nil, ErrInvalidArgument.WithMessage("curveFamily is nil")
 	}
 	if publicMaterial == nil {
 		return nil, ErrInvalidArgument.WithMessage("publicMaterial is nil")
 	}
-	scheme, err := bls.NewLongKeyScheme(curveFamily, bls.POP)
+	scheme, err := newScheme(curveFamily, bls.POP)
 	if err != nil {
-		return nil, errs.Wrap(err).WithMessage("failed to create BLS long key scheme")
+		return nil, errs.Wrap(err).WithMessage(schemeErrorMessage)
 	}
-	out, err := newAggregator(scheme, publicMaterial, curveFamily.SourceSubGroup(), rogueKeyAlg, bls.LongKey)
+	out, err := newAggregator(scheme, publicMaterial, signatureSubGroup(curveFamily), rogueKeyAlg, variant)
 	if err != nil {
-		return nil, errs.Wrap(err).WithMessage("failed to create long key aggregator")
+		return nil, errs.Wrap(err).WithMessage(aggregatorErrorMessage)
 	}
 	return out, nil
 }

--- a/pkg/network/errors.go
+++ b/pkg/network/errors.go
@@ -3,8 +3,11 @@ package network
 import "github.com/bronlabs/errs-go/errs"
 
 var (
-	ErrInvalidArgument   = errs.New("invalid argument")
-	ErrFailed            = errs.New("failed")
-	ErrReceiveBufferFull = errs.New("receive buffer full")
-	ErrDuplicateMessage  = errs.New("duplicate message")
+	ErrInvalidArgument       = errs.New("invalid argument")
+	ErrFailed                = errs.New("failed")
+	ErrFrameTooLarge         = errs.New("frame too large")
+	ErrPayloadTooLarge       = errs.New("payload too large")
+	ErrCorrelationIDTooLarge = errs.New("correlation id too large")
+	ErrReceiveBufferFull     = errs.New("receive buffer full")
+	ErrDuplicateMessage      = errs.New("duplicate message")
 )

--- a/pkg/network/router.go
+++ b/pkg/network/router.go
@@ -24,31 +24,59 @@ type Delivery interface {
 	Receive(ctx context.Context) (from sharing.ID, message []byte, err error)
 }
 
-// maxReceiveBufferSize caps the number of out-of-order messages the router
-// will buffer for later retrieval. It bounds memory usage when peers (or a
-// compromised transport) inject messages with unexpected correlation IDs or
-// sender identities.
-const maxReceiveBufferSize = 10000
+const (
+	defaultMaxFrameBytes         = 16 << 20
+	defaultMaxPayloadBytes       = 16 << 20
+	defaultMaxCorrelationIDBytes = 1024
+	defaultMaxBufferedMessages   = 10000
+	defaultMaxBufferedBytes      = 128 << 20
+)
+
+// RouterOptions bounds untrusted transport input and retained out-of-order messages.
+// Zero-valued fields use production defaults.
+type RouterOptions struct {
+	MaxFrameBytes         int
+	MaxPayloadBytes       int
+	MaxCorrelationIDBytes int
+	MaxBufferedMessages   int
+	MaxBufferedBytes      int
+}
 
 // Router orchestrates correlation-aware sending and receiving over a Delivery.
 type Router struct {
-	receiveBuffer []routerMessage
-	delivery      Delivery
-	quorumSet     ds.Set[sharing.ID]
+	receiveBuffer      []routerMessage
+	receiveBufferBytes int
+	delivery           Delivery
+	options            RouterOptions
+	quorumSet          ds.Set[sharing.ID]
 }
 
 // NewRouter wraps a Delivery with buffering and correlation-aware routing.
 func NewRouter(delivery Delivery) *Router {
+	//nolint:exhaustruct // zero-valued options request production defaults.
+	return NewRouterWithOptions(delivery, RouterOptions{})
+}
+
+// NewRouterWithOptions wraps a Delivery with buffering and bounded correlation-aware routing.
+func NewRouterWithOptions(delivery Delivery, options RouterOptions) *Router {
 	return &Router{
-		receiveBuffer: nil,
-		delivery:      delivery,
-		quorumSet:     hashset.NewComparable(delivery.Quorum()...).Freeze(),
+		receiveBuffer:      nil,
+		receiveBufferBytes: 0,
+		delivery:           delivery,
+		options:            options.withDefaults(),
+		quorumSet:          hashset.NewComparable(delivery.Quorum()...).Freeze(),
 	}
 }
 
 // SendTo serialises and sends messages to the given recipients under a correlation identifier.
 func (r *Router) SendTo(ctx context.Context, correlationID string, messages map[sharing.ID][]byte) error {
+	if len(correlationID) > r.options.MaxCorrelationIDBytes {
+		return ErrCorrelationIDTooLarge.WithMessage("correlation id exceeded %d bytes", r.options.MaxCorrelationIDBytes)
+	}
 	for id, payload := range messages {
+		if len(payload) > r.options.MaxPayloadBytes {
+			return ErrPayloadTooLarge.WithMessage("payload exceeded %d bytes", r.options.MaxPayloadBytes)
+		}
 		//nolint:exhaustruct // From is optional
 		message := routerMessage{
 			CorrelationID: correlationID,
@@ -57,6 +85,9 @@ func (r *Router) SendTo(ctx context.Context, correlationID string, messages map[
 		serializedMessage, err := serde.MarshalCBOR(&message)
 		if err != nil {
 			return errs.Wrap(err).WithMessage("failed to marshal message")
+		}
+		if len(serializedMessage) > r.options.MaxFrameBytes {
+			return ErrFrameTooLarge.WithMessage("frame exceeded %d bytes", r.options.MaxFrameBytes)
 		}
 		if err := r.delivery.Send(ctx, id, serializedMessage); err != nil {
 			return errs.Wrap(err).WithMessage("failed to send message")
@@ -92,6 +123,7 @@ func (r *Router) ReceiveFrom(ctx context.Context, correlationID string, froms ..
 		}
 	}
 	r.receiveBuffer = kept
+	r.receiveBufferBytes = bufferedMessagesBytes(kept)
 
 	for !sliceutils.IsSuperSet(slices.Collect(maps.Keys(received)), froms) {
 		from, serializedMessage, err := r.delivery.Receive(ctx)
@@ -103,18 +135,23 @@ func (r *Router) ReceiveFrom(ctx context.Context, correlationID string, froms ..
 		if !r.quorumSet.Contains(from) {
 			continue
 		}
+		if len(serializedMessage) > r.options.MaxFrameBytes {
+			return nil, ErrFrameTooLarge.WithMessage("frame exceeded %d bytes", r.options.MaxFrameBytes)
+		}
 		message, err := serde.UnmarshalCBOR[routerMessage](serializedMessage)
 		if err != nil {
 			return nil, errs.Wrap(err).WithMessage("failed to decode message")
 		}
+		if err := r.validateMessage(message); err != nil {
+			return nil, err
+		}
 
 		if message.CorrelationID == correlationID {
 			if _, ok := expected[from]; !ok {
-				if len(r.receiveBuffer) >= maxReceiveBufferSize {
-					return nil, ErrReceiveBufferFull.WithMessage("receive buffer exceeded %d messages", maxReceiveBufferSize)
-				}
 				message.From = from
-				r.receiveBuffer = append(r.receiveBuffer, message)
+				if err := r.bufferMessage(message); err != nil {
+					return nil, err
+				}
 				continue
 			}
 
@@ -125,11 +162,10 @@ func (r *Router) ReceiveFrom(ctx context.Context, correlationID string, froms ..
 			}
 			received[from] = message.Payload
 		} else {
-			if len(r.receiveBuffer) >= maxReceiveBufferSize {
-				return nil, ErrReceiveBufferFull.WithMessage("receive buffer exceeded %d messages", maxReceiveBufferSize)
-			}
 			message.From = from
-			r.receiveBuffer = append(r.receiveBuffer, message)
+			if err := r.bufferMessage(message); err != nil {
+				return nil, err
+			}
 		}
 	}
 	return received, nil
@@ -149,4 +185,58 @@ type routerMessage struct {
 	From          sharing.ID `cbor:"from"`
 	CorrelationID string     `cbor:"correlationID"`
 	Payload       []byte     `cbor:"payload"`
+}
+
+func (options RouterOptions) withDefaults() RouterOptions {
+	if options.MaxFrameBytes <= 0 {
+		options.MaxFrameBytes = defaultMaxFrameBytes
+	}
+	if options.MaxPayloadBytes <= 0 {
+		options.MaxPayloadBytes = defaultMaxPayloadBytes
+	}
+	if options.MaxCorrelationIDBytes <= 0 {
+		options.MaxCorrelationIDBytes = defaultMaxCorrelationIDBytes
+	}
+	if options.MaxBufferedMessages <= 0 {
+		options.MaxBufferedMessages = defaultMaxBufferedMessages
+	}
+	if options.MaxBufferedBytes <= 0 {
+		options.MaxBufferedBytes = defaultMaxBufferedBytes
+	}
+	return options
+}
+
+func (r *Router) validateMessage(message routerMessage) error {
+	if len(message.Payload) > r.options.MaxPayloadBytes {
+		return ErrPayloadTooLarge.WithMessage("payload exceeded %d bytes", r.options.MaxPayloadBytes)
+	}
+	if len(message.CorrelationID) > r.options.MaxCorrelationIDBytes {
+		return ErrCorrelationIDTooLarge.WithMessage("correlation id exceeded %d bytes", r.options.MaxCorrelationIDBytes)
+	}
+	return nil
+}
+
+func (r *Router) bufferMessage(message routerMessage) error {
+	if len(r.receiveBuffer) >= r.options.MaxBufferedMessages {
+		return ErrReceiveBufferFull.WithMessage("receive buffer exceeded %d messages", r.options.MaxBufferedMessages)
+	}
+	messageBytes := bufferedMessageBytes(message)
+	if messageBytes > r.options.MaxBufferedBytes || r.receiveBufferBytes > r.options.MaxBufferedBytes-messageBytes {
+		return ErrReceiveBufferFull.WithMessage("receive buffer exceeded %d bytes", r.options.MaxBufferedBytes)
+	}
+	r.receiveBuffer = append(r.receiveBuffer, message)
+	r.receiveBufferBytes += messageBytes
+	return nil
+}
+
+func bufferedMessagesBytes(messages []routerMessage) int {
+	total := 0
+	for _, message := range messages {
+		total += bufferedMessageBytes(message)
+	}
+	return total
+}
+
+func bufferedMessageBytes(message routerMessage) int {
+	return len(message.CorrelationID) + len(message.Payload)
 }

--- a/pkg/network/router_test.go
+++ b/pkg/network/router_test.go
@@ -74,3 +74,90 @@ func TestRouterReceiveFromFiltersUnexpectedSenders(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, map[sharing.ID][]byte{2: []byte("expected")}, received)
 }
+
+func TestRouterReceiveFromRejectsOversizedFrameBeforeDecode(t *testing.T) {
+	t.Parallel()
+
+	delivery := &stubDelivery{
+		partyID: 1,
+		quorum:  []sharing.ID{1, 2},
+		queue: []queuedDelivery{
+			{from: 2, message: []byte("not-cbor")},
+		},
+	}
+
+	router := network.NewRouterWithOptions(delivery, network.RouterOptions{MaxFrameBytes: 4})
+	_, err := router.ReceiveFrom(context.Background(), "cid", 2)
+	require.Error(t, err)
+	require.ErrorIs(t, err, network.ErrFrameTooLarge)
+}
+
+func TestRouterReceiveFromRejectsOversizedPayload(t *testing.T) {
+	t.Parallel()
+
+	message := marshalRouterTestMessage(t, "cid", []byte("too large"))
+	delivery := &stubDelivery{
+		partyID: 1,
+		quorum:  []sharing.ID{1, 2},
+		queue: []queuedDelivery{
+			{from: 2, message: message},
+		},
+	}
+
+	router := network.NewRouterWithOptions(delivery, network.RouterOptions{MaxPayloadBytes: 4})
+	_, err := router.ReceiveFrom(context.Background(), "cid", 2)
+	require.Error(t, err)
+	require.ErrorIs(t, err, network.ErrPayloadTooLarge)
+}
+
+func TestRouterReceiveFromRejectsOversizedCorrelationID(t *testing.T) {
+	t.Parallel()
+
+	message := marshalRouterTestMessage(t, "correlation-id", []byte("ok"))
+	delivery := &stubDelivery{
+		partyID: 1,
+		quorum:  []sharing.ID{1, 2},
+		queue: []queuedDelivery{
+			{from: 2, message: message},
+		},
+	}
+
+	router := network.NewRouterWithOptions(delivery, network.RouterOptions{MaxCorrelationIDBytes: 4})
+	_, err := router.ReceiveFrom(context.Background(), "cid", 2)
+	require.Error(t, err)
+	require.ErrorIs(t, err, network.ErrCorrelationIDTooLarge)
+}
+
+func TestRouterReceiveFromCapsBufferedBytes(t *testing.T) {
+	t.Parallel()
+
+	first := marshalRouterTestMessage(t, "other", []byte("1234567"))
+	second := marshalRouterTestMessage(t, "other", []byte("7654321"))
+	delivery := &stubDelivery{
+		partyID: 1,
+		quorum:  []sharing.ID{1, 2, 3},
+		queue: []queuedDelivery{
+			{from: 3, message: first},
+			{from: 3, message: second},
+		},
+	}
+
+	router := network.NewRouterWithOptions(delivery, network.RouterOptions{MaxBufferedBytes: 16})
+	_, err := router.ReceiveFrom(context.Background(), "cid", 2)
+	require.Error(t, err)
+	require.ErrorIs(t, err, network.ErrReceiveBufferFull)
+}
+
+func marshalRouterTestMessage(t *testing.T, correlationID string, payload []byte) []byte {
+	t.Helper()
+
+	message, err := serde.MarshalCBOR(&struct {
+		CorrelationID string `cbor:"correlationID"`
+		Payload       []byte `cbor:"payload"`
+	}{
+		CorrelationID: correlationID,
+		Payload:       payload,
+	})
+	require.NoError(t, err)
+	return message
+}

--- a/pkg/ot/base/vsot/participant.go
+++ b/pkg/ot/base/vsot/participant.go
@@ -30,6 +30,26 @@ type participant[P curves.Point[P, B, S], B algebra.FieldElement[B], S algebra.P
 	prng      io.Reader
 }
 
+func newParticipant[P curves.Point[P, B, S], B algebra.FieldElement[B], S algebra.PrimeFieldElement[S]](ctx *session.Context, suite *Suite[P, B, S], prng io.Reader, round int) (*participant[P, B, S], error) {
+	if suite == nil || ctx == nil || prng == nil {
+		return nil, ot.ErrInvalidArgument.WithMessage("invalid args")
+	}
+	if ctx.Quorum().Size() != 2 {
+		return nil, ot.ErrInvalidArgument.WithMessage("invalid quorum size")
+	}
+
+	copartyID := slices.Collect(ctx.OtherPartiesOrdered())[0]
+	sessionID := ctx.SessionID()
+	ctx.Transcript().AppendDomainSeparator(fmt.Sprintf("%s-%s", transcriptLabel, hex.EncodeToString(sessionID[:])))
+	return &participant[P, B, S]{
+		ctx:       ctx,
+		copartyID: copartyID,
+		suite:     suite,
+		round:     round,
+		prng:      prng,
+	}, nil
+}
+
 func (p *participant[P, B, S]) hash(idx int, b, a P, data []byte) ([]byte, error) {
 	sessionID := p.ctx.SessionID()
 	digest, err := hashing.HashIndexLengthPrefixed(p.suite.HashFunc(), binary.LittleEndian.AppendUint64(nil, uint64(idx)), sessionID[:], b.ToCompressed(), a.ToCompressed(), data)
@@ -56,25 +76,14 @@ type senderState[P curves.Point[P, B, S], B algebra.FieldElement[B], S algebra.P
 
 // NewSender creates a VSOT sender bound to the session, suite, transcript, and randomness source.
 func NewSender[P curves.Point[P, B, S], B algebra.FieldElement[B], S algebra.PrimeFieldElement[S]](ctx *session.Context, suite *Suite[P, B, S], prng io.Reader) (*Sender[P, B, S], error) {
-	if suite == nil || ctx == nil || prng == nil {
-		return nil, ot.ErrInvalidArgument.WithMessage("invalid args")
-	}
-	if ctx.Quorum().Size() != 2 {
-		return nil, ot.ErrInvalidArgument.WithMessage("invalid quorum size")
+	p, err := newParticipant(ctx, suite, prng, 1)
+	if err != nil {
+		return nil, err
 	}
 
-	copartyID := slices.Collect(ctx.OtherPartiesOrdered())[0]
-	sessionID := ctx.SessionID()
-	ctx.Transcript().AppendDomainSeparator(fmt.Sprintf("%s-%s", transcriptLabel, hex.EncodeToString(sessionID[:])))
 	s := &Sender[P, B, S]{
-		participant: participant[P, B, S]{
-			ctx:       ctx,
-			copartyID: copartyID,
-			suite:     suite,
-			round:     1,
-			prng:      prng,
-		},
-		state: senderState[P, B, S]{}, //nolint:exhaustruct // zero value, populated during protocol
+		participant: *p,
+		state:       senderState[P, B, S]{}, //nolint:exhaustruct // zero value, populated during protocol
 	}
 
 	return s, nil
@@ -99,25 +108,14 @@ type receiverState[P curves.Point[P, B, S], B algebra.FieldElement[B], S algebra
 
 // NewReceiver creates a VSOT receiver bound to the session, suite, transcript, and randomness source.
 func NewReceiver[P curves.Point[P, B, S], B algebra.FieldElement[B], S algebra.PrimeFieldElement[S]](ctx *session.Context, suite *Suite[P, B, S], prng io.Reader) (*Receiver[P, B, S], error) {
-	if suite == nil || ctx == nil || prng == nil {
-		return nil, ot.ErrInvalidArgument.WithMessage("invalid args")
-	}
-	if ctx.Quorum().Size() != 2 {
-		return nil, ot.ErrInvalidArgument.WithMessage("invalid quorum size")
+	p, err := newParticipant(ctx, suite, prng, 2)
+	if err != nil {
+		return nil, err
 	}
 
-	copartyID := slices.Collect(ctx.OtherPartiesOrdered())[0]
-	sessionID := ctx.SessionID()
-	ctx.Transcript().AppendDomainSeparator(fmt.Sprintf("%s-%s", transcriptLabel, hex.EncodeToString(sessionID[:])))
 	r := &Receiver[P, B, S]{
-		participant: participant[P, B, S]{
-			ctx:       ctx,
-			copartyID: copartyID,
-			suite:     suite,
-			round:     2,
-			prng:      prng,
-		},
-		state: receiverState[P, B, S]{}, //nolint:exhaustruct // zero value, populated during protocol
+		participant: *p,
+		state:       receiverState[P, B, S]{}, //nolint:exhaustruct // zero value, populated during protocol
 	}
 
 	return r, nil

--- a/pkg/signatures/ecdsa/ecdsa_test.go
+++ b/pkg/signatures/ecdsa/ecdsa_test.go
@@ -44,6 +44,7 @@ func Test_HappyPath(t *testing.T) {
 	require.NoError(t, err)
 	signature, err := signer.Sign(message[:])
 	require.NoError(t, err)
+	require.True(t, signature.IsNormalized())
 	verifier, err := scheme.Verifier()
 	require.NoError(t, err)
 	err = verifier.Verify(signature, pk, message[:])
@@ -249,8 +250,16 @@ func Test_RFC6979(t *testing.T) {
 		signature, err := signer.Sign([]byte(v.message))
 		require.NoError(t, err)
 
+		expectedSBytes, err := hex.DecodeString(v.s)
+		require.NoError(t, err)
+		expectedS, err := curve.ScalarField().FromBytes(expectedSBytes)
+		require.NoError(t, err)
+		expectedSignature, err := ecdsa.NewSignature(signature.R(), expectedS, nil)
+		require.NoError(t, err)
+		expectedSignature.Normalise()
+
 		require.Equal(t, v.r, strings.ToUpper(hex.EncodeToString(signature.R().Bytes())))
-		require.Equal(t, v.s, strings.ToUpper(hex.EncodeToString(signature.S().Bytes())))
+		require.Equal(t, strings.ToUpper(hex.EncodeToString(expectedSignature.S().Bytes())), strings.ToUpper(hex.EncodeToString(signature.S().Bytes())))
 	}
 }
 
@@ -301,7 +310,9 @@ func Test_VerifyNonMalleably(t *testing.T) {
 	defaultVerifier, err := scheme.Verifier()
 	require.NoError(t, err)
 	require.NoError(t, defaultVerifier.Verify(lowS, pk, message[:]), "default verifier must accept low-s")
-	require.NoError(t, defaultVerifier.Verify(highS, pk, message[:]), "default verifier accepts high-s (malleability baseline)")
+	err = defaultVerifier.Verify(highS, pk, message[:])
+	require.Error(t, err, "default verifier must reject high-s")
+	require.ErrorIs(t, err, signatures.ErrVerificationFailed)
 
 	nonMalleableVerifier, err := scheme.Verifier(ecdsa.VerifyNonMalleably[*k256.Point, *k256.BaseFieldElement, *k256.Scalar])
 	require.NoError(t, err)
@@ -310,4 +321,12 @@ func Test_VerifyNonMalleably(t *testing.T) {
 	err = nonMalleableVerifier.Verify(highS, pk, message[:])
 	require.Error(t, err, "non-malleable verifier must reject high-s")
 	require.ErrorIs(t, err, signatures.ErrVerificationFailed)
+
+	legacyVerifier, err := scheme.Verifier(ecdsa.AllowMalleableSignatures[*k256.Point, *k256.BaseFieldElement, *k256.Scalar])
+	require.NoError(t, err)
+	require.NoError(t, legacyVerifier.Verify(highS, pk, message[:]), "legacy verifier must accept high-s only by opt-in")
+
+	legacyVerifier, err = ecdsa.NewMalleableVerifier(suite)
+	require.NoError(t, err)
+	require.NoError(t, legacyVerifier.Verify(highS, pk, message[:]), "legacy verifier constructor must accept high-s")
 }

--- a/pkg/signatures/ecdsa/scheme.go
+++ b/pkg/signatures/ecdsa/scheme.go
@@ -55,7 +55,8 @@ func (s *Scheme[P, B, S]) Signer(sk *PrivateKey[P, B, S], _ ...signatures.Signer
 }
 
 // Verifier creates a verifier for validating ECDSA signatures.
-// Note that verifier by default accepts malleable signatures (i.e., those with s in the upper half of the field). To enforce non-malleability, apply the VerifyNonMalleably option.
+// The verifier rejects malleable high-S signatures by default. Apply
+// AllowMalleableSignatures only for legacy inputs that require high-S support.
 func (s *Scheme[P, B, S]) Verifier(opts ...signatures.VerifierOption[*Verifier[P, B, S], *PublicKey[P, B, S], []byte, *Signature[S]]) (*Verifier[P, B, S], error) {
 	vr, err := NewVerifier(s.suite)
 	if err != nil {

--- a/pkg/signatures/ecdsa/signer.go
+++ b/pkg/signatures/ecdsa/signer.go
@@ -104,6 +104,7 @@ func (s *Signer[P, B, S]) Sign(message []byte) (*Signature[S], error) {
 			continue
 		}
 		if recoveredPk.Equal(s.sk.pk) {
+			signature.Normalise()
 			return signature, nil
 		}
 	}

--- a/pkg/signatures/ecdsa/verifier.go
+++ b/pkg/signatures/ecdsa/verifier.go
@@ -28,9 +28,18 @@ func VerifyNonMalleably[P curves.Point[P, B, S], B algebra.PrimeFieldElement[B],
 	return nil
 }
 
+// AllowMalleableSignatures configures the verifier to accept legacy high-S signatures.
+func AllowMalleableSignatures[P curves.Point[P, B, S], B algebra.PrimeFieldElement[B], S algebra.PrimeFieldElement[S]](vf *Verifier[P, B, S]) error {
+	if vf == nil {
+		return signatures.ErrInvalidArgument.WithMessage("verifier is nil")
+	}
+	vf.mustBeNonMalleable = false
+	return nil
+}
+
 // NewVerifier creates a verifier with the given cryptographic suite.
 // The suite defines the curve and hash function used for verification.
-// Note that the output verifier does not enforce non-malleability by default; apply the VerifyNonMalleably option to enable that check.
+// The output verifier rejects malleable high-S signatures by default.
 func NewVerifier[P curves.Point[P, B, S], B algebra.PrimeFieldElement[B], S algebra.PrimeFieldElement[S]](suite *Suite[P, B, S]) (*Verifier[P, B, S], error) {
 	if suite == nil {
 		return nil, signatures.ErrInvalidArgument.WithMessage("suite is nil")
@@ -38,8 +47,18 @@ func NewVerifier[P curves.Point[P, B, S], B algebra.PrimeFieldElement[B], S alge
 
 	v := &Verifier[P, B, S]{
 		suite:              suite,
-		mustBeNonMalleable: false,
+		mustBeNonMalleable: true,
 	}
+	return v, nil
+}
+
+// NewMalleableVerifier creates a legacy verifier that accepts high-S signatures.
+func NewMalleableVerifier[P curves.Point[P, B, S], B algebra.PrimeFieldElement[B], S algebra.PrimeFieldElement[S]](suite *Suite[P, B, S]) (*Verifier[P, B, S], error) {
+	v, err := NewVerifier(suite)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("verifier creation failed")
+	}
+	v.mustBeNonMalleable = false
 	return v, nil
 }
 

--- a/pkg/signatures/schnorrlike/schnorr/schnorr_test.go
+++ b/pkg/signatures/schnorrlike/schnorr/schnorr_test.go
@@ -39,6 +39,24 @@ func Test_VanillaSchnorr_BasicSigning_k256(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func Test_VanillaSchnorr_NewPrivateKeyRejectsMismatchedPublicKey(t *testing.T) {
+	t.Parallel()
+
+	group := k256.NewCurve()
+	scalarField := k256.NewScalarField()
+	skValue := scalarField.FromUint64(2)
+
+	validPk, err := vanilla.NewPublicKey(group.ScalarBaseMul(skValue))
+	require.NoError(t, err)
+	_, err = vanilla.NewPrivateKey(skValue, validPk)
+	require.NoError(t, err)
+
+	wrongPk, err := vanilla.NewPublicKey(group.ScalarBaseMul(scalarField.FromUint64(3)))
+	require.NoError(t, err)
+	_, err = vanilla.NewPrivateKey(skValue, wrongPk)
+	require.Error(t, err)
+}
+
 func Test_VanillaSchnorr_BasicSigning_p256(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/signatures/schnorrlike/schnorrlike.go
+++ b/pkg/signatures/schnorrlike/schnorrlike.go
@@ -173,7 +173,7 @@ func (pk *PublicKey[PKV, S]) UnmarshalCBOR(data []byte) error {
 
 // NewPrivateKey creates a Schnorr private key from a scalar value.
 // The scalar must be non-zero and the corresponding public key must be provided.
-// The public key should satisfy P = x·G where x is the private key scalar.
+// The public key must satisfy P = x·G where x is the private key scalar.
 func NewPrivateKey[PKV GroupElement[PKV, SKV], SKV Scalar[SKV]](value SKV, publicKey *PublicKey[PKV, SKV]) (*PrivateKey[PKV, SKV], error) {
 	if utils.IsNil(value) {
 		return nil, signatures.ErrInvalidArgument.WithMessage("value is nil")
@@ -183,6 +183,16 @@ func NewPrivateKey[PKV GroupElement[PKV, SKV], SKV Scalar[SKV]](value SKV, publi
 	}
 	if publicKey == nil {
 		return nil, signatures.ErrInvalidArgument.WithMessage("publicKey is nil")
+	}
+	if utils.IsNil(publicKey.Value()) {
+		return nil, signatures.ErrInvalidArgument.WithMessage("publicKey value is nil")
+	}
+	group, err := algebra.StructureAs[Group[PKV, SKV]](publicKey.Value().Structure())
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("public key structure is not supported")
+	}
+	if !group.ScalarBaseOp(value).Equal(publicKey.Value()) {
+		return nil, signatures.ErrFailed.WithMessage("private key doesn't match public key")
 	}
 	return &PrivateKey[PKV, SKV]{
 		PrivateKeyTrait: signatures.PrivateKeyTrait[PKV, SKV]{

--- a/scripts/ci/ct-check.sh
+++ b/scripts/ci/ct-check.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+mul_go="$root/pkg/base/algebra/impl/mul.go"
+
+if rg -n 'precomputed\[w\]' "$mul_go"; then
+	echo "secret scalar multiplication must not index precomputed tables by scalar windows" >&2
+	exit 1
+fi
+
+secret_msm="$(awk '
+	/^func MultiScalarMulLowLevel\[/ { in_secret = 1 }
+	/^func MultiScalarMulLowLevelVartimePublic\[/ { in_secret = 0 }
+	in_secret { print }
+' "$mul_go")"
+
+if printf '%s\n' "$secret_msm" | rg -n 'buckets\[win\]|if win == 0|IsZero\(\)'; then
+	echo "secret multi-scalar multiplication must not branch or index by scalar windows" >&2
+	exit 1
+fi
+

--- a/scripts/ci/unsafe-api-check.sh
+++ b/scripts/ci/unsafe-api-check.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+
+if rg -n '"github.com/bronlabs/bron-crypto/pkg/base/prng/pcg"' "$root" \
+	--glob '*.go' \
+	--glob '!**/*_test.go' \
+	--glob '!**/testutils/**' \
+	--glob '!pkg/base/prng/pcg/**' \
+	--glob '!tools/**'; then
+	echo "pkg/base/prng/pcg is test-only and must not be imported by production packages" >&2
+	exit 1
+fi
+

--- a/scripts/ci/verify-boringssl-pin.sh
+++ b/scripts/ci/verify-boringssl-pin.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+makefile="$root/Makefile"
+
+if ! rg -q '^BORINGSSL_COMMIT := [0-9a-f]{40}$' "$makefile"; then
+	echo "BoringSSL must be pinned with BORINGSSL_COMMIT := <40-hex-sha>" >&2
+	exit 1
+fi
+
+if rg -n 'BORINGSSL_TAG|--branch "\$?\{?BORINGSSL_TAG\}?"' "$makefile"; then
+	echo "BoringSSL must not be fetched by mutable tag" >&2
+	exit 1
+fi
+
+if ! rg -q 'rev-parse HEAD' "$makefile"; then
+	echo "BoringSSL checkout must verify git rev-parse HEAD against BORINGSSL_COMMIT" >&2
+	exit 1
+fi
+

--- a/scripts/ci/verify-workflows.sh
+++ b/scripts/ci/verify-workflows.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+workflow_dir="$root/.github/workflows"
+
+if rg -n 'runs-on:\s*self-hosted' "$workflow_dir"; then
+	echo "workflows must not run untrusted code on self-hosted runners" >&2
+	exit 1
+fi
+
+missing_permissions=0
+for workflow in "$workflow_dir"/*.yml "$workflow_dir"/*.yaml; do
+	[[ -e "$workflow" ]] || continue
+	if ! rg -q '^permissions:' "$workflow"; then
+		echo "$workflow is missing explicit permissions" >&2
+		missing_permissions=1
+	fi
+done
+if [[ "$missing_permissions" -ne 0 ]]; then
+	exit 1
+fi
+
+missing_timeout=0
+for workflow in "$workflow_dir"/*.yml "$workflow_dir"/*.yaml; do
+	[[ -e "$workflow" ]] || continue
+	if ! rg -q '^\s+timeout-minutes:' "$workflow"; then
+		echo "$workflow is missing job timeout-minutes" >&2
+		missing_timeout=1
+	fi
+done
+if [[ "$missing_timeout" -ne 0 ]]; then
+	exit 1
+fi
+
+uses_status=0
+while IFS=: read -r file line text; do
+	ref="${text##*@}"
+	ref="${ref%% *}"
+	ref="${ref%%#*}"
+	if [[ ! "$ref" =~ ^[0-9a-f]{40}$ ]]; then
+		echo "$file:$line uses an action that is not pinned to a full SHA: $text" >&2
+		uses_status=1
+	fi
+done < <(rg -n 'uses:\s*[^[:space:]]+@' "$workflow_dir")
+
+exit "$uses_status"

--- a/tools/field-codegen/field.go.tmpl
+++ b/tools/field-codegen/field.go.tmpl
@@ -3,6 +3,7 @@
 package {{ .Pkg }}
 
 import (
+	"encoding/binary"
 	"encoding/hex"
 	"io"
 	"math/big"
@@ -55,12 +56,23 @@ func (f *{{- .TypeName }}) SetUint64(v uint64) {
 }
 
 func (f *{{- .TypeName }}) SetLimbs(data []uint64) (ok ct.Bool) {
-	{{ .FiatPrefix -}}ToMontgomery(&f.{{- .FiatPrefix -}}MontgomeryDomainFieldElement, (*{{- .FiatPrefix -}}NonMontgomeryDomainFieldElement)(data))
-	return 1
+	if len(data) != {{ .TypeName -}}Limbs {
+		return 0
+	}
+
+	var byteData [{{ .TypeName -}}Bytes]byte
+	for i, limb := range data {
+		binary.LittleEndian.PutUint64(byteData[8*i:8*(i+1)], limb)
+	}
+
+	return f.SetBytes(byteData[:])
 }
 
 func (f *{{- .TypeName }}) SetBytes(data []byte) (ok ct.Bool) {
 	if len(data) != {{ .TypeName -}}Bytes {
+		return 0
+	}
+	if isCanonical{{ .TypeName }}Bytes(data) == ct.False {
 		return 0
 	}
 
@@ -68,6 +80,16 @@ func (f *{{- .TypeName }}) SetBytes(data []byte) (ok ct.Bool) {
 	{{ .FiatPrefix -}}FromBytes((*[{{ .TypeName -}}Limbs]uint64)(&nonMonty), (*[{{ .TypeName -}}Bytes]uint8)(data))
 	{{ .FiatPrefix -}}ToMontgomery(&f.{{- .FiatPrefix -}}MontgomeryDomainFieldElement, &nonMonty)
 	return 1
+}
+
+func isCanonical{{ .TypeName }}Bytes(data []byte) ct.Bool {
+	var lt, gt ct.Choice
+	for i := {{ .TypeName -}}Bytes - 1; i >= 0; i-- {
+		undecided := (lt | gt).Not()
+		lt |= undecided & ct.Less(data[i], {{ .TypeName -}}Modulus[i])
+		gt |= undecided & ct.Greater(data[i], {{ .TypeName -}}Modulus[i])
+	}
+	return lt
 }
 
 func (f *{{- .TypeName }}) SetBytesWide(data []byte) (ok ct.Bool) {


### PR DESCRIPTION
## Security hardening roadmap

This PR hardens bron-crypto across scalar arithmetic, serialization, CI/supply-chain controls, network input bounds, and misuse-resistant signature/key APIs.

Because the underlying findings are security-sensitive and the target repository is public, this is opened as a draft PR from a fork so maintainers can control review and disclosure timing.

## What changed

- Replaced secret-scalar table indexing in low-level scalar multiplication with constant-time table scanning and added CT static regression checks.
- Made low-level MSM scalar handling safe by default and exposed the old bucketed implementation only as an explicit public-scalar variable-time API.
- Pinned and verified BoringSSL by immutable commit SHA, moved PR CI to GitHub-hosted runners, minimized workflow permissions, and added security workflow gates.
- Enforced canonical generated field/scalar `SetBytes`/`SetLimbs` decoding before Montgomery conversion while preserving wide/reducing APIs.
- Added router frame, payload, correlation ID, buffered message, and buffered byte limits.
- Made ECDSA low-S non-malleability the default and normalized signer output.
- Validated Schnorr-like private/public key binding in private key construction.
- Marked PCG as test-only/insecure, blocked production imports through CI, and made its test reader safe for concurrent test use.
- Added security targets and scripts for CT, workflow policy, BoringSSL pinning, unsafe API/import checks, govulncheck, and fuzz smoke coverage.

## Security roadmap checklist

### Phase 1 — Constant-time scalar arithmetic
- [x] Secret scalar multiplication has no secret-derived table indexes.
- [x] Secret MSM has no secret-derived bucket indexes or branches by default.
- [x] Variable-time MSM is renamed/documented as public-input-only.
- [x] CT regression tests added.

### Phase 2 — CI and supply chain
- [x] Untrusted PRs do not run on self-hosted runners.
- [x] BoringSSL is pinned by immutable commit SHA.
- [x] Workflow permissions are minimal.
- [x] Workflow policy checks added.

### Phase 3 — Serialization and network limits
- [x] Field/scalar `FromBytes` rejects non-canonical encodings.
- [x] `FromWideBytes` remains the explicit reducing API.
- [x] Router frame/payload/correlation/buffer byte limits added.
- [x] CBOR/network smoke and negative tests added.

### Phase 4 — Misuse-resistant APIs
- [x] ECDSA verifier rejects high-S by default.
- [x] ECDSA signer returns normalized signatures.
- [x] Schnorr private-key constructor validates public-key binding.
- [x] PCG is test-only or blocked from production imports.

### Phase 5 — Assurance
- [x] `make security` added.
- [x] `make ct-check` added.
- [x] `govulncheck` added.
- [x] Fuzz smoke tests added.
- [ ] Full malicious protocol test expansion remains follow-up work.

### Test commands
- [x] `make test`
- [ ] `make test-race` — still fails in pre-existing `pkg/base/nt/numct` / `pkg/base/nt/num` race-test paths outside this PR's primary scope.
- [x] `make lint`
- [x] `make security`
- [x] `make fuzz-smoke`

## Validation

- `make lint` passed.
- `make test` passed.
- `make security` passed.
- `make fuzz-smoke` passed.
- `git diff --check` passed.
- `make test-race` still reports existing races in `pkg/base/nt/numct` / `pkg/base/nt/num` tests.
