### PR TITLE
ci: move to GitHub-hosted runner with hardened workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,17 +6,50 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
     env:
       GODEBUG: "cpu.avx2=off"
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - name: Harden runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
-          clean: true
+          egress-policy: audit
+          disable-sudo: false
+          disable-telemetry: true
+
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Cache BoringSSL
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: thirdparty/boringssl
+          key: boringssl-${{ runner.os }}-${{ hashFiles('Makefile') }}
+
+      - name: Install BoringSSL build tools
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends cmake ninja-build build-essential
+
+      - name: Install golangci-lint
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0
 
       - name: Build
         run: make build test lint


### PR DESCRIPTION
## Summary

Switch CI from self-hosted to `ubuntu-24.04` to remove the fork-PR attack surface on this public repository, and add standard supply-chain hardening to the workflow itself.

## What changed

- `runs-on: self-hosted` → `runs-on: ubuntu-24.04` (immutable, pinned)
- All actions pinned by full commit SHA (`actions/checkout`, `actions/setup-go`, `actions/cache`, `step-security/harden-runner`)
- `step-security/harden-runner@v2.19.1` in `audit` mode (egress monitoring + telemetry disabled)
- `permissions: contents: read` (least privilege `GITHUB_TOKEN`)
- `persist-credentials: false` on `actions/checkout`
- `timeout-minutes: 60` + `concurrency` group (cancel redundant runs on rapid pushes)
- BoringSSL build cached via `actions/cache`, keyed on `hashFiles('Makefile')` (where `BORINGSSL_TAG` lives) — first run rebuilds, subsequent runs reuse the cache
- Go version pulled from `go.mod` via `actions/setup-go` with module cache enabled
- Build prerequisites installed via apt (`cmake`, `ninja-build`, `build-essential`)
- `golangci-lint` installed via `go install ...@v2.9.0` (cryptographically pinned through `proxy.golang.org` + `sum.golang.org`)

## Why

A public repo with `runs-on: self-hosted` exposes the maintainer's runner infrastructure to fork-PR code execution. The recent TanStack npm supply-chain incident demonstrated the chain: fork PR / `pull_request_target` → GitHub Actions cache poisoning → OIDC token extraction from the runner process. Moving public CI to disposable GitHub-hosted runners eliminates that class of attack entirely. The hardening additions (SHA-pinning, harden-runner audit, persist-credentials: false, restricted permissions) close the secondary risks that remain even on GitHub-hosted runners.

## Test plan

- [ ] CI passes on this PR (workflow exercises itself on `pull_request`)
- [ ] Inspect `harden-runner` audit output in the run summary to verify egress endpoints look sane
- [ ] After merge, confirm next push to master triggers a green CI on the new workflow
