### PR TITLE
Implement CGGMP21 aff-g, aff-g*, dec, and enc-elg proofs

### DIFF
--- a/pkg/proofs/cggmp21/affg/README.md
+++ b/pkg/proofs/cggmp21/affg/README.md
@@ -1,0 +1,114 @@
+# CGGMP21 Paillier Affine Operation with Group Commitment
+
+This package implements the sigma protocol Pi aff-g from Appendix A.3, Figure 25 of CGGMP21.
+
+The statement is `(G, g, N0, N1, C, D, Y, X)`. The witness is `(x, y, rho, rhoY)` such that:
+
+$$
+x \in \pm 2^\ell,\quad y \in \pm 2^{\ell'},\quad X = g^x,
+$$
+
+$$
+Y = (1+N_1)^y \rho_Y^{N_1} \bmod N_1^2,
+$$
+
+and
+
+$$
+D = C^x (1+N_0)^y \rho^{N_0} \bmod N_0^2.
+$$
+
+The implementation exposes `ell` as `l`, `ell'` as `lPrime`, and the statistical slack as `epsilon`.
+
+## Protocol
+
+The prover samples:
+
+$$
+\alpha \leftarrow \pm 2^{\ell+\epsilon},\quad
+\beta \leftarrow \pm 2^{\ell'+\epsilon},
+$$
+
+$$
+r \leftarrow Z^*_{N_0},\quad r_Y \leftarrow Z^*_{N_1},
+$$
+
+$$
+\gamma \leftarrow \pm 2^{\ell+\epsilon}\hat N,\quad
+m \leftarrow \pm 2^\ell\hat N,
+$$
+
+$$
+\delta \leftarrow \pm 2^{\ell'+\epsilon}\hat N,\quad
+\mu \leftarrow \pm 2^{\ell'}\hat N.
+$$
+
+It sends:
+
+$$
+A = C^\alpha (1+N_0)^\beta r^{N_0} \bmod N_0^2,\quad
+B_x = g^\alpha,\quad
+B_y = (1+N_1)^\beta r_Y^{N_1} \bmod N_1^2,
+$$
+
+$$
+E = s^\alpha t^\gamma,\quad
+F = s^\beta t^\delta,\quad
+S = s^x t^m,\quad
+T = s^y t^\mu \pmod{\hat N}.
+$$
+
+For challenge `e`, the response is:
+
+$$
+z_1 = \alpha + ex,\quad
+z_2 = \beta + ey,\quad
+z_3 = \gamma + em,\quad
+z_4 = \delta + e\mu,
+$$
+
+$$
+w = r\rho^e \bmod N_0,\quad
+w_Y = r_Y\rho_Y^e \bmod N_1.
+$$
+
+The verifier checks:
+
+$$
+C^{z_1}(1+N_0)^{z_2}w^{N_0} = AD^e \bmod N_0^2,
+$$
+
+$$
+g^{z_1} = B_xX^e,
+$$
+
+$$
+(1+N_1)^{z_2}w_Y^{N_1} = B_yY^e \bmod N_1^2,
+$$
+
+$$
+s^{z_1}t^{z_3} = ES^e,\quad
+s^{z_2}t^{z_4} = FT^e \pmod{\hat N},
+$$
+
+and the widened ranges:
+
+$$
+z_1 \in \pm 2^{\ell+\epsilon},\quad z_2 \in \pm 2^{\ell'+\epsilon}.
+$$
+
+## Implementation Notes
+
+- `Statement` stores `N0`, `N1`, `C`, `D`, `Y`, and `X`.
+- `Witness` stores `x` as `*num.Int`, `y` as a Paillier plaintext under `N1`, and the two Paillier nonces.
+- Signed integer samples use byte-aligned two's-complement sampling over the requested bit length, so `±q` is interpreted as `[-q/2, q/2)`. A sample from `2^t * N` is implemented as a signed sample with bit length `t + bitlen(N)`.
+- `ValidateStatement` checks that the witness opens `X`, `Y`, and `D`, and that `x` and `y` satisfy the configured narrow ranges.
+- Statement validation checks that both Paillier moduli can encode the widened `z2` range `lPrime + epsilon` in their symmetric plaintext intervals.
+- The challenge is interpreted as signed two's-complement big-endian bytes with computational-security length.
+
+## Reference
+
+<!-- paper: docs/papers/2021-060_20241021_172019.pdf [Appendix A.3, Figure 25] -->
+- Canetti, Gennaro, Goldfeder, Makriyannis, Peled.
+  [UC Non-Interactive, Proactive, Threshold ECDSA with Identifiable Aborts](https://eprint.iacr.org/2021/060),
+  Appendix A.3, Figure 25.

--- a/pkg/proofs/cggmp21/affg/README.md
+++ b/pkg/proofs/cggmp21/affg/README.md
@@ -104,7 +104,7 @@ $$
 - Signed integer samples use byte-aligned two's-complement sampling over the requested bit length, so `±q` is interpreted as `[-q/2, q/2)`. A sample from `2^t * N` is implemented as a signed sample with bit length `t + bitlen(N)`.
 - `ValidateStatement` checks that the witness opens `X`, `Y`, and `D`, and that `x` and `y` satisfy the configured narrow ranges.
 - Statement validation checks that both Paillier moduli can encode the widened `z2` range `lPrime + epsilon` in their symmetric plaintext intervals.
-- The challenge is interpreted as signed two's-complement big-endian bytes with computational-security length.
+- The challenge is interpreted as signed two's-complement big-endian bytes with `base.ComputationalSecurityBytesCeil` length. This intentionally fixes the Fiat-Shamir challenge domain to 128 bits rather than the paper's curve-order-sized challenge.
 
 ## Reference
 

--- a/pkg/proofs/cggmp21/affg/affg.go
+++ b/pkg/proofs/cggmp21/affg/affg.go
@@ -1,0 +1,341 @@
+package affg
+
+import (
+	"encoding/binary"
+
+	"github.com/bronlabs/errs-go/errs"
+
+	"github.com/bronlabs/bron-crypto/pkg/base/algebra"
+	"github.com/bronlabs/bron-crypto/pkg/base/curves"
+	"github.com/bronlabs/bron-crypto/pkg/base/nt/num"
+	"github.com/bronlabs/bron-crypto/pkg/base/serde"
+	"github.com/bronlabs/bron-crypto/pkg/base/utils"
+	"github.com/bronlabs/bron-crypto/pkg/base/utils/sliceutils"
+	"github.com/bronlabs/bron-crypto/pkg/commitments/intcom"
+	"github.com/bronlabs/bron-crypto/pkg/encryption/paillier"
+	"github.com/bronlabs/bron-crypto/pkg/proofs/sigma"
+)
+
+const (
+	// Name identifies the CGGMP21 Paillier affine operation with group commitment proof.
+	Name sigma.Name = "CGGMP21_PAILLIER_AFFINE_OP_WITH_COMMITMENT"
+)
+
+// Statement is the public input (N0, N1, C, D, Y, X) for CGGMP21 Figure 25.
+type Statement[G curves.Point[G, B, S], B algebra.PrimeFieldElement[B], S algebra.PrimeFieldElement[S]] struct {
+	n0 *paillier.PublicKey
+	n1 *paillier.PublicKey
+	c  *paillier.Ciphertext
+	d  *paillier.Ciphertext
+	y  *paillier.Ciphertext
+	x  G
+}
+
+type statementDTO[G curves.Point[G, B, S], B algebra.PrimeFieldElement[B], S algebra.PrimeFieldElement[S]] struct {
+	N0 *paillier.PublicKey  `cbor:"n0"`
+	N1 *paillier.PublicKey  `cbor:"n1"`
+	C  *paillier.Ciphertext `cbor:"c"`
+	D  *paillier.Ciphertext `cbor:"d"`
+	Y  *paillier.Ciphertext `cbor:"y"`
+	X  G                    `cbor:"x"`
+}
+
+// NewStatement constructs a Paillier affine statement.
+func NewStatement[G curves.Point[G, B, S], B algebra.PrimeFieldElement[B], S algebra.PrimeFieldElement[S]](
+	n0 *paillier.PublicKey,
+	n1 *paillier.PublicKey,
+	c *paillier.Ciphertext,
+	d *paillier.Ciphertext,
+	y *paillier.Ciphertext,
+	x G,
+) (*Statement[G, B, S], error) {
+	if n0 == nil || n1 == nil || c == nil || d == nil || y == nil || utils.IsNil(x) {
+		return nil, ErrInvalidArgument.WithMessage("statement values must not be nil")
+	}
+	return &Statement[G, B, S]{
+		n0: n0,
+		n1: n1,
+		c:  c,
+		d:  d,
+		y:  y,
+		x:  x,
+	}, nil
+}
+
+// MarshalCBOR serialises the statement to CBOR format.
+func (s *Statement[G, B, S]) MarshalCBOR() ([]byte, error) {
+	dto := &statementDTO[G, B, S]{
+		N0: s.n0,
+		N1: s.n1,
+		C:  s.c,
+		D:  s.d,
+		Y:  s.y,
+		X:  s.x,
+	}
+	out, err := serde.MarshalCBOR(dto)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not marshal statement to CBOR")
+	}
+	return out, nil
+}
+
+// UnmarshalCBOR deserialises the statement from CBOR format.
+func (s *Statement[G, B, S]) UnmarshalCBOR(data []byte) error {
+	dto, err := serde.UnmarshalCBOR[*statementDTO[G, B, S]](data)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not unmarshal statement from CBOR")
+	}
+	if dto == nil {
+		return ErrInvalidArgument.WithMessage("statement DTO must not be nil")
+	}
+	statement, err := NewStatement(dto.N0, dto.N1, dto.C, dto.D, dto.Y, dto.X)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("invalid statement data")
+	}
+	*s = *statement
+	return nil
+}
+
+// Bytes serialises the statement for transcript binding.
+func (s *Statement[G, B, S]) Bytes() []byte {
+	out := binary.LittleEndian.AppendUint64(nil, 6)
+	out = sliceutils.AppendLengthPrefixed(out, s.n0.Group().N().Bytes())
+	out = sliceutils.AppendLengthPrefixed(out, s.n1.Group().N().Bytes())
+	out = sliceutils.AppendLengthPrefixed(out, s.c.Bytes())
+	out = sliceutils.AppendLengthPrefixed(out, s.d.Bytes())
+	out = sliceutils.AppendLengthPrefixed(out, s.y.Bytes())
+	out = sliceutils.AppendLengthPrefixed(out, s.x.Bytes())
+	return out
+}
+
+// Witness is the secret input (x, y, rho, rhoY) from CGGMP21 Figure 25.
+type Witness struct {
+	x    *num.Int
+	y    *paillier.Plaintext
+	rho  *paillier.Nonce
+	rhoY *paillier.Nonce
+}
+
+// NewWitness constructs a Paillier affine witness.
+func NewWitness(x *num.Int, y *paillier.Plaintext, rho, rhoY *paillier.Nonce) (*Witness, error) {
+	if x == nil || y == nil || rho == nil || rhoY == nil {
+		return nil, ErrInvalidArgument.WithMessage("witness values must not be nil")
+	}
+	return &Witness{
+		x:    x.Clone(),
+		y:    y,
+		rho:  rho,
+		rhoY: rhoY,
+	}, nil
+}
+
+// State stores the prover's sampled randomness between sigma rounds.
+type State struct {
+	alpha *num.Int
+	beta  *num.Int
+	gamma *num.Int
+	m     *num.Int
+	delta *num.Int
+	mu    *num.Int
+	r     *paillier.Nonce
+	ry    *paillier.Nonce
+}
+
+// NewState constructs the prover state retained between sigma rounds.
+func NewState(alpha, beta, gamma, m, delta, mu *num.Int, r, ry *paillier.Nonce) (*State, error) {
+	for _, elem := range []*num.Int{alpha, beta, gamma, m, delta, mu} {
+		if elem == nil {
+			return nil, ErrInvalidArgument.WithMessage("state integers must not be nil")
+		}
+	}
+	if r == nil || ry == nil {
+		return nil, ErrInvalidArgument.WithMessage("state nonces must not be nil")
+	}
+	return &State{
+		alpha: alpha,
+		beta:  beta,
+		gamma: gamma,
+		m:     m,
+		delta: delta,
+		mu:    mu,
+		r:     r,
+		ry:    ry,
+	}, nil
+}
+
+// Commitment is the prover's first message (A, Bx, By, E, F, S, T).
+type Commitment[G curves.Point[G, B, S], B algebra.PrimeFieldElement[B], S algebra.PrimeFieldElement[S]] struct {
+	a  *paillier.Ciphertext
+	bx G
+	by *paillier.Ciphertext
+	e  *intcom.Commitment
+	f  *intcom.Commitment
+	s  *intcom.Commitment
+	t  *intcom.Commitment
+}
+
+type commitmentDTO[G curves.Point[G, B, S], B algebra.PrimeFieldElement[B], S algebra.PrimeFieldElement[S]] struct {
+	A  *paillier.Ciphertext `cbor:"a"`
+	BX G                    `cbor:"bx"`
+	BY *paillier.Ciphertext `cbor:"by"`
+	E  *intcom.Commitment   `cbor:"e"`
+	F  *intcom.Commitment   `cbor:"f"`
+	S  *intcom.Commitment   `cbor:"s"`
+	T  *intcom.Commitment   `cbor:"t"`
+}
+
+// NewCommitment constructs a Paillier affine commitment.
+func NewCommitment[G curves.Point[G, B, S], B algebra.PrimeFieldElement[B], S algebra.PrimeFieldElement[S]](
+	a *paillier.Ciphertext,
+	bx G,
+	by *paillier.Ciphertext,
+	e *intcom.Commitment,
+	f *intcom.Commitment,
+	s *intcom.Commitment,
+	t *intcom.Commitment,
+) (*Commitment[G, B, S], error) {
+	if a == nil || by == nil || e == nil || f == nil || s == nil || t == nil || utils.IsNil(bx) {
+		return nil, ErrInvalidArgument.WithMessage("commitment values must not be nil")
+	}
+	return &Commitment[G, B, S]{
+		a:  a,
+		bx: bx,
+		by: by,
+		e:  e,
+		f:  f,
+		s:  s,
+		t:  t,
+	}, nil
+}
+
+// MarshalCBOR serialises the commitment to CBOR format.
+func (c *Commitment[G, B, S]) MarshalCBOR() ([]byte, error) {
+	dto := &commitmentDTO[G, B, S]{
+		A:  c.a,
+		BX: c.bx,
+		BY: c.by,
+		E:  c.e,
+		F:  c.f,
+		S:  c.s,
+		T:  c.t,
+	}
+	out, err := serde.MarshalCBOR(dto)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not marshal commitment to CBOR")
+	}
+	return out, nil
+}
+
+// UnmarshalCBOR deserialises the commitment from CBOR format.
+func (c *Commitment[G, B, S]) UnmarshalCBOR(data []byte) error {
+	dto, err := serde.UnmarshalCBOR[*commitmentDTO[G, B, S]](data)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not unmarshal commitment from CBOR")
+	}
+	if dto == nil {
+		return ErrInvalidArgument.WithMessage("commitment DTO must not be nil")
+	}
+	commitment, err := NewCommitment(dto.A, dto.BX, dto.BY, dto.E, dto.F, dto.S, dto.T)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("invalid commitment data")
+	}
+	*c = *commitment
+	return nil
+}
+
+// Bytes serialises the commitment for transcript binding.
+func (c *Commitment[G, B, S]) Bytes() []byte {
+	out := binary.LittleEndian.AppendUint64(nil, 7)
+	out = sliceutils.AppendLengthPrefixed(out, c.a.Bytes())
+	out = sliceutils.AppendLengthPrefixed(out, c.bx.Bytes())
+	out = sliceutils.AppendLengthPrefixed(out, c.by.Bytes())
+	out = sliceutils.AppendLengthPrefixed(out, c.e.Value().Bytes())
+	out = sliceutils.AppendLengthPrefixed(out, c.f.Value().Bytes())
+	out = sliceutils.AppendLengthPrefixed(out, c.s.Value().Bytes())
+	out = sliceutils.AppendLengthPrefixed(out, c.t.Value().Bytes())
+	return out
+}
+
+// Response is the prover's final message (z1, z2, z3, z4, w, wy).
+type Response struct {
+	z1 *num.Int
+	z2 *num.Int
+	z3 *num.Int
+	z4 *num.Int
+	w  *paillier.Nonce
+	wy *paillier.Nonce
+}
+
+type responseDTO struct {
+	Z1 *num.Int        `cbor:"z1"`
+	Z2 *num.Int        `cbor:"z2"`
+	Z3 *num.Int        `cbor:"z3"`
+	Z4 *num.Int        `cbor:"z4"`
+	W  *paillier.Nonce `cbor:"w"`
+	WY *paillier.Nonce `cbor:"wy"`
+}
+
+// NewResponse constructs a Paillier affine response.
+func NewResponse(z1, z2, z3, z4 *num.Int, w, wy *paillier.Nonce) (*Response, error) {
+	for _, elem := range []*num.Int{z1, z2, z3, z4} {
+		if elem == nil {
+			return nil, ErrInvalidArgument.WithMessage("response integers must not be nil")
+		}
+	}
+	if w == nil || wy == nil {
+		return nil, ErrInvalidArgument.WithMessage("response nonces must not be nil")
+	}
+	return &Response{
+		z1: z1,
+		z2: z2,
+		z3: z3,
+		z4: z4,
+		w:  w,
+		wy: wy,
+	}, nil
+}
+
+// MarshalCBOR serialises the response to CBOR format.
+func (r *Response) MarshalCBOR() ([]byte, error) {
+	dto := &responseDTO{
+		Z1: r.z1,
+		Z2: r.z2,
+		Z3: r.z3,
+		Z4: r.z4,
+		W:  r.w,
+		WY: r.wy,
+	}
+	out, err := serde.MarshalCBOR(dto)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not marshal response to CBOR")
+	}
+	return out, nil
+}
+
+// UnmarshalCBOR deserialises the response from CBOR format.
+func (r *Response) UnmarshalCBOR(data []byte) error {
+	dto, err := serde.UnmarshalCBOR[*responseDTO](data)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not unmarshal response from CBOR")
+	}
+	if dto == nil {
+		return ErrInvalidArgument.WithMessage("response DTO must not be nil")
+	}
+	response, err := NewResponse(dto.Z1, dto.Z2, dto.Z3, dto.Z4, dto.W, dto.WY)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("invalid response data")
+	}
+	*r = *response
+	return nil
+}
+
+// Bytes serialises the response for transcript binding.
+func (r *Response) Bytes() []byte {
+	out := binary.LittleEndian.AppendUint64(nil, 6)
+	for _, z := range []*num.Int{r.z1, r.z2, r.z3, r.z4} {
+		out = sliceutils.AppendLengthPrefixed(out, z.Bytes())
+	}
+	out = sliceutils.AppendLengthPrefixed(out, r.w.Bytes())
+	out = sliceutils.AppendLengthPrefixed(out, r.wy.Bytes())
+	return out
+}

--- a/pkg/proofs/cggmp21/affg/affg_smoke_test.go
+++ b/pkg/proofs/cggmp21/affg/affg_smoke_test.go
@@ -1,0 +1,19 @@
+package affg_test
+
+import (
+	"github.com/bronlabs/bron-crypto/pkg/base/algebra"
+	"github.com/bronlabs/bron-crypto/pkg/base/curves"
+	"github.com/bronlabs/bron-crypto/pkg/proofs/cggmp21/affg"
+	"github.com/bronlabs/bron-crypto/pkg/proofs/sigma"
+	"github.com/bronlabs/bron-crypto/pkg/signatures/ecdsa"
+)
+
+func _[G curves.Point[G, B, S], B algebra.PrimeFieldElement[B], S algebra.PrimeFieldElement[S]](_ ecdsa.Curve[G, B, S]) {
+	var _ sigma.Statement = (*affg.Statement[G, B, S])(nil)
+	var _ sigma.Witness = (*affg.Witness)(nil)
+	var _ sigma.State = (*affg.State)(nil)
+	var _ sigma.Commitment = (*affg.Commitment[G, B, S])(nil)
+	var _ sigma.Response = (*affg.Response)(nil)
+
+	var _ sigma.Protocol[*affg.Statement[G, B, S], *affg.Witness, *affg.Commitment[G, B, S], *affg.State, *affg.Response] = (*affg.Protocol[G, B, S])(nil)
+}

--- a/pkg/proofs/cggmp21/affg/doc.go
+++ b/pkg/proofs/cggmp21/affg/doc.go
@@ -1,3 +1,12 @@
 // Package affg implements CGGMP21 Figure 25, the Paillier affine operation
 // sigma protocol with a group commitment.
+//
+// CBOR unmarshalling validates local structure and nested type constructors.
+// Contextual checks that depend on protocol parameters or statement/witness
+// relations are performed by Protocol.ValidateStatement and Protocol.Verify.
+//
+// The simulator uses the standard honest-verifier sigma shape: sample a
+// response for the fixed challenge, then reconstruct the commitment. CGGMP21
+// leaves the affine-operation simulator implicit; this is analogous to the
+// simulator construction used by encelg.
 package affg

--- a/pkg/proofs/cggmp21/affg/doc.go
+++ b/pkg/proofs/cggmp21/affg/doc.go
@@ -1,0 +1,3 @@
+// Package affg implements CGGMP21 Figure 25, the Paillier affine operation
+// sigma protocol with a group commitment.
+package affg

--- a/pkg/proofs/cggmp21/affg/errors.go
+++ b/pkg/proofs/cggmp21/affg/errors.go
@@ -1,0 +1,12 @@
+package affg
+
+import "github.com/bronlabs/errs-go/errs"
+
+var (
+	// ErrInvalidArgument indicates missing or inconsistent protocol inputs.
+	ErrInvalidArgument = errs.New("invalid argument")
+	// ErrValidationFailed indicates that a statement/witness pair is malformed or inconsistent.
+	ErrValidationFailed = errs.New("validation failed")
+	// ErrVerificationFailed indicates a failed sigma-protocol verification.
+	ErrVerificationFailed = errs.New("verification failed")
+)

--- a/pkg/proofs/cggmp21/affg/helpers.go
+++ b/pkg/proofs/cggmp21/affg/helpers.go
@@ -1,0 +1,84 @@
+package affg
+
+import (
+	"crypto/sha3"
+	"encoding/hex"
+	"io"
+	"math/big"
+
+	"github.com/bronlabs/errs-go/errs"
+
+	"github.com/bronlabs/bron-crypto/pkg/base/algebra"
+	"github.com/bronlabs/bron-crypto/pkg/base/nt/num"
+	"github.com/bronlabs/bron-crypto/pkg/base/utils/sliceutils"
+	"github.com/bronlabs/bron-crypto/pkg/commitments/intcom"
+	"github.com/bronlabs/bron-crypto/pkg/encryption/paillier"
+)
+
+func commitmentKeyDigest(commitmentKey *intcom.CommitmentKey) string {
+	out := []byte{}
+	out = sliceutils.AppendLengthPrefixed(out, commitmentKey.Group().Modulus().Bytes())
+	out = sliceutils.AppendLengthPrefixed(out, commitmentKey.S().Bytes())
+	out = sliceutils.AppendLengthPrefixed(out, commitmentKey.T().Bytes())
+	sum := sha3.Sum256(out)
+	return hex.EncodeToString(sum[:])
+}
+
+func intSampleRangeSymmetricBits(bitLen int, prngReader io.Reader) (*num.Int, error) {
+	buf := make([]byte, bitLen/8)
+	if _, err := io.ReadFull(prngReader, buf); err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not sample integer bytes")
+	}
+
+	out, err := num.Z().FromTwosComplementBytesBE(buf)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not parse sampled integer")
+	}
+	return out, nil
+}
+
+func intInSignedBitRange(v *num.Int, bitLen int) bool {
+	return v.Abs().TrueLen() <= bitLen
+}
+
+func intToPlaintext(v *num.Int, paillierKey *paillier.PublicKey) (*paillier.Plaintext, error) {
+	out, err := paillier.NewPlaintextSymmetric(v, paillierKey.PlaintextGroup().Modulus())
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not create signed Paillier plaintext")
+	}
+	return out, nil
+}
+
+func intToScalar[S algebra.PrimeFieldElement[S]](v *num.Int, scalarField algebra.PrimeField[S]) (S, error) {
+	var nilS S
+	if v == nil {
+		return nilS, ErrInvalidArgument.WithMessage("integer must not be nil")
+	}
+	if scalarField == nil {
+		return nilS, ErrInvalidArgument.WithMessage("scalar field must not be nil")
+	}
+
+	modulus := scalarField.Order().Big()
+	reduced := new(big.Int).Mod(v.Big(), modulus)
+	if reduced.Sign() == 0 {
+		return scalarField.FromUint64(0), nil
+	}
+	out, err := scalarField.FromBytesBEReduce(reduced.Bytes())
+	if err != nil {
+		return nilS, errs.Wrap(err).WithMessage("could not reduce integer to scalar")
+	}
+	return out, nil
+}
+
+func signedBoundFitsPaillier(bits int, paillierKey *paillier.PublicKey) error {
+	if paillierKey == nil {
+		return ErrInvalidArgument.WithMessage("Paillier key must not be nil")
+	}
+	modulus := paillierKey.PlaintextGroup().Modulus()
+	bound := num.Z().One().Lsh(uint(bits))
+	halfModulus := modulus.Rsh(1).Lift()
+	if !bound.IsLessThanOrEqual(halfModulus) {
+		return ErrValidationFailed.WithMessage("2^%d must fit in the Paillier symmetric plaintext range", bits)
+	}
+	return nil
+}

--- a/pkg/proofs/cggmp21/affg/helpers.go
+++ b/pkg/proofs/cggmp21/affg/helpers.go
@@ -38,7 +38,7 @@ func intSampleRangeSymmetricBits(bitLen int, prngReader io.Reader) (*num.Int, er
 }
 
 func intInSignedBitRange(v *num.Int, bitLen int) bool {
-	return v.Abs().TrueLen() <= bitLen
+	return v.Abs().TrueLen() < bitLen
 }
 
 func intToPlaintext(v *num.Int, paillierKey *paillier.PublicKey) (*paillier.Plaintext, error) {

--- a/pkg/proofs/cggmp21/affg/protocol.go
+++ b/pkg/proofs/cggmp21/affg/protocol.go
@@ -1,0 +1,733 @@
+package affg
+
+import (
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/bronlabs/errs-go/errs"
+
+	"github.com/bronlabs/bron-crypto/pkg/base"
+	"github.com/bronlabs/bron-crypto/pkg/base/algebra"
+	"github.com/bronlabs/bron-crypto/pkg/base/curves"
+	"github.com/bronlabs/bron-crypto/pkg/base/nt/num"
+	"github.com/bronlabs/bron-crypto/pkg/base/utils"
+	"github.com/bronlabs/bron-crypto/pkg/commitments/intcom"
+	"github.com/bronlabs/bron-crypto/pkg/encryption/paillier"
+	"github.com/bronlabs/bron-crypto/pkg/proofs/sigma"
+	"github.com/bronlabs/bron-crypto/pkg/signatures/ecdsa"
+)
+
+// Protocol implements the CGGMP21 Paillier affine operation with group commitment proof from Figure 25.
+type Protocol[G curves.Point[G, B, S], B algebra.PrimeFieldElement[B], S algebra.PrimeFieldElement[S]] struct {
+	name            sigma.Name
+	ringPedersenKey *intcom.CommitmentKey
+	l               int
+	lPrime          int
+	epsilon         int
+	curve           ecdsa.Curve[G, B, S]
+	prng            io.Reader
+}
+
+// NewProtocol constructs the CGGMP21 Figure 25 Paillier affine sigma protocol.
+func NewProtocol[G curves.Point[G, B, S], B algebra.PrimeFieldElement[B], S algebra.PrimeFieldElement[S]](ringPedersenKey *intcom.CommitmentKey, l, lPrime, epsilon int, curve ecdsa.Curve[G, B, S], prng io.Reader) (*Protocol[G, B, S], error) {
+	if ringPedersenKey == nil || ringPedersenKey.Group().Modulus().TrueLen()%8 != 0 {
+		return nil, ErrInvalidArgument.WithMessage("ringPedersenKey is required")
+	}
+	if prng == nil {
+		return nil, ErrInvalidArgument.WithMessage("prng is required")
+	}
+	if utils.IsNil(curve) {
+		return nil, ErrInvalidArgument.WithMessage("curve is required")
+	}
+	if (l <= 0) || (l%8 != 0) {
+		return nil, ErrInvalidArgument.WithMessage("l must be a multiple of 8")
+	}
+	if (lPrime <= 0) || (lPrime%8 != 0) {
+		return nil, ErrInvalidArgument.WithMessage("lPrime must be a multiple of 8")
+	}
+	if (epsilon <= 0) || (epsilon%8 != 0) {
+		return nil, ErrInvalidArgument.WithMessage("epsilon must be a multiple of 8")
+	}
+
+	k := curve.ScalarField().BitLen()
+	if k < base.ComputationalSecurityBits {
+		return nil, ErrInvalidArgument.WithMessage("invalid curve")
+	}
+	if l < k {
+		return nil, ErrInvalidArgument.WithMessage("invalid l")
+	}
+	if epsilon < l+k {
+		return nil, ErrInvalidArgument.WithMessage("invalid epsilon")
+	}
+	if lPrime < l+epsilon+2*l {
+		return nil, ErrInvalidArgument.WithMessage("invalid lPrime")
+	}
+	logN := ringPedersenKey.Group().Modulus().TrueLen()
+	if logN < lPrime+epsilon {
+		return nil, ErrInvalidArgument.WithMessage("invalid ring pedersen key")
+	}
+	if !testing.Testing() && logN < base.IFCKeyLength {
+		return nil, ErrInvalidArgument.WithMessage("invalid ring pedersen key len")
+	}
+
+	name := sigma.Name(fmt.Sprintf(
+		"%s_L=%d_LPRIME=%d_EPS=%d_CURVE=%s_CK=%s",
+		Name,
+		l,
+		lPrime,
+		epsilon,
+		curve.Name(),
+		commitmentKeyDigest(ringPedersenKey),
+	))
+	p := &Protocol[G, B, S]{
+		name:            name,
+		ringPedersenKey: ringPedersenKey,
+		l:               l,
+		lPrime:          lPrime,
+		epsilon:         epsilon,
+		curve:           curve,
+		prng:            prng,
+	}
+	return p, nil
+}
+
+// Name returns the protocol identifier, including public parameters.
+func (p *Protocol[G, B, S]) Name() sigma.Name {
+	return p.name
+}
+
+// ComputeProverCommitment generates the prover's first message.
+func (p *Protocol[G, B, S]) ComputeProverCommitment(statement *Statement[G, B, S], witness *Witness) (*Commitment[G, B, S], *State, error) {
+	if statement == nil {
+		return nil, nil, ErrInvalidArgument.WithMessage("statement must not be nil")
+	}
+	if witness == nil {
+		return nil, nil, ErrInvalidArgument.WithMessage("witness must not be nil")
+	}
+	if err := p.validateStatement(statement); err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("invalid statement")
+	}
+
+	state, err := p.sampleState(statement)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not sample prover state")
+	}
+	commitment, err := p.computeCommitment(statement, witness, state)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not compute prover commitment")
+	}
+	return commitment, state, nil
+}
+
+// ComputeProverResponse generates the prover response for a fixed challenge.
+func (p *Protocol[G, B, S]) ComputeProverResponse(statement *Statement[G, B, S], witness *Witness, commitment *Commitment[G, B, S], state *State, challenge sigma.ChallengeBytes) (*Response, error) {
+	if statement == nil {
+		return nil, ErrInvalidArgument.WithMessage("statement must not be nil")
+	}
+	if witness == nil {
+		return nil, ErrInvalidArgument.WithMessage("witness must not be nil")
+	}
+	if commitment == nil {
+		return nil, ErrInvalidArgument.WithMessage("commitment must not be nil")
+	}
+	if state == nil {
+		return nil, ErrInvalidArgument.WithMessage("state must not be nil")
+	}
+	if err := p.validateStatement(statement); err != nil {
+		return nil, errs.Wrap(err).WithMessage("invalid statement")
+	}
+	e, err := p.mapChallenge(challenge)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("invalid challenge")
+	}
+
+	y := witness.y.Normalise()
+	z1 := state.alpha.Add(e.Mul(witness.x))
+	z2 := state.beta.Add(e.Mul(y))
+	z3 := state.gamma.Add(e.Mul(state.m))
+	z4 := state.delta.Add(e.Mul(state.mu))
+
+	rhoE, err := statement.n0.NonceScalarOp(witness.rho, e)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not compute rho^e")
+	}
+	w, err := statement.n0.NonceOp(state.r, rhoE)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not compute w")
+	}
+	rhoYE, err := statement.n1.NonceScalarOp(witness.rhoY, e)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not compute rhoY^e")
+	}
+	wy, err := statement.n1.NonceOp(state.ry, rhoYE)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not compute wy")
+	}
+
+	response, err := NewResponse(z1, z2, z3, z4, w, wy)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not create response")
+	}
+	return response, nil
+}
+
+// Verify checks the Figure 25 equality checks and widened response ranges.
+func (p *Protocol[G, B, S]) Verify(statement *Statement[G, B, S], commitment *Commitment[G, B, S], challenge sigma.ChallengeBytes, response *Response) error {
+	if statement == nil {
+		return ErrInvalidArgument.WithMessage("statement must not be nil")
+	}
+	if commitment == nil {
+		return ErrInvalidArgument.WithMessage("commitment must not be nil")
+	}
+	if response == nil {
+		return ErrInvalidArgument.WithMessage("response must not be nil")
+	}
+	if err := p.validateStatement(statement); err != nil {
+		return errs.Wrap(err).WithMessage("invalid statement")
+	}
+	if err := p.validateCommitment(statement, commitment); err != nil {
+		return errs.Wrap(err).WithMessage("invalid commitment")
+	}
+	if err := p.validateResponse(statement, response); err != nil {
+		return errs.Wrap(err).WithMessage("invalid response")
+	}
+	e, err := p.mapChallenge(challenge)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("invalid challenge")
+	}
+
+	if !intInSignedBitRange(response.z1, p.l+p.epsilon) {
+		return ErrVerificationFailed.WithMessage("z1 is out of range")
+	}
+	if !intInSignedBitRange(response.z2, p.lPrime+p.epsilon) {
+		return ErrVerificationFailed.WithMessage("z2 is out of range")
+	}
+
+	cZ1, err := statement.n0.CiphertextScalarOp(statement.c, response.z1)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not compute C^z1")
+	}
+	z2N0, err := intToPlaintext(response.z2, statement.n0)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not create z2 plaintext for N0")
+	}
+	encZ2, err := statement.n0.EncryptWithNonce(z2N0, response.w)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not encrypt z2 under N0")
+	}
+	leftN0, err := statement.n0.CiphertextOp(cZ1, encZ2)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not compute first equality left side")
+	}
+	dE, err := statement.n0.CiphertextScalarOp(statement.d, e)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not compute D^e")
+	}
+	rightN0, err := statement.n0.CiphertextOp(commitment.a, dE)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not compute first equality right side")
+	}
+	if !leftN0.Equal(rightN0) {
+		return ErrVerificationFailed.WithMessage("N0 Paillier equality check failed")
+	}
+
+	z1Scalar, err := intToScalar(response.z1, p.curve.ScalarField())
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not convert z1 to scalar")
+	}
+	eScalar, err := intToScalar(e, p.curve.ScalarField())
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not convert challenge to scalar")
+	}
+	leftGroup := p.curve.ScalarBaseMul(z1Scalar)
+	rightGroup := commitment.bx.Op(statement.x.ScalarOp(eScalar))
+	if !leftGroup.Equal(rightGroup) {
+		return ErrVerificationFailed.WithMessage("curve equality check failed")
+	}
+
+	z2N1, err := intToPlaintext(response.z2, statement.n1)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not create z2 plaintext for N1")
+	}
+	leftN1, err := statement.n1.EncryptWithNonce(z2N1, response.wy)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not encrypt z2 under N1")
+	}
+	yE, err := statement.n1.CiphertextScalarOp(statement.y, e)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not compute Y^e")
+	}
+	rightN1, err := statement.n1.CiphertextOp(commitment.by, yE)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not compute N1 equality right side")
+	}
+	if !leftN1.Equal(rightN1) {
+		return ErrVerificationFailed.WithMessage("N1 Paillier equality check failed")
+	}
+
+	z1Commitment, err := p.commit(response.z1, response.z3)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not compute z1 commitment")
+	}
+	sE, err := p.ringPedersenKey.CommitmentScalarOp(commitment.s, e)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not compute S^e")
+	}
+	rightE, err := p.ringPedersenKey.CommitmentOp(commitment.e, sE)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not compute E equality right side")
+	}
+	if !z1Commitment.Equal(rightE) {
+		return ErrVerificationFailed.WithMessage("first Pedersen equality check failed")
+	}
+
+	z2Commitment, err := p.commit(response.z2, response.z4)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not compute z2 commitment")
+	}
+	tE, err := p.ringPedersenKey.CommitmentScalarOp(commitment.t, e)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not compute T^e")
+	}
+	rightF, err := p.ringPedersenKey.CommitmentOp(commitment.f, tE)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not compute F equality right side")
+	}
+	if !z2Commitment.Equal(rightF) {
+		return ErrVerificationFailed.WithMessage("second Pedersen equality check failed")
+	}
+
+	return nil
+}
+
+// RunSimulator creates an honest-verifier simulated transcript for a fixed challenge.
+func (p *Protocol[G, B, S]) RunSimulator(statement *Statement[G, B, S], challenge sigma.ChallengeBytes) (*Commitment[G, B, S], *Response, error) {
+	if statement == nil {
+		return nil, nil, ErrInvalidArgument.WithMessage("statement must not be nil")
+	}
+	if err := p.validateStatement(statement); err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("invalid statement")
+	}
+	e, err := p.mapChallenge(challenge)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("invalid challenge")
+	}
+
+	nHatBitLen := p.ringPedersenKey.Group().Modulus().TrueLen()
+	z1, err := intSampleRangeSymmetricBits(p.l+p.epsilon, p.prng)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not sample z1")
+	}
+	z2, err := intSampleRangeSymmetricBits(p.lPrime+p.epsilon, p.prng)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not sample z2")
+	}
+	z3, err := intSampleRangeSymmetricBits(p.l+p.epsilon+nHatBitLen, p.prng)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not sample z3")
+	}
+	z4, err := intSampleRangeSymmetricBits(p.lPrime+p.epsilon+nHatBitLen, p.prng)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not sample z4")
+	}
+	w, err := statement.n0.SampleNonce(p.prng)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not sample w")
+	}
+	wy, err := statement.n1.SampleNonce(p.prng)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not sample wy")
+	}
+	response, err := NewResponse(z1, z2, z3, z4, w, wy)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not create response")
+	}
+
+	lambdaS, err := intSampleRangeSymmetricBits(p.l+nHatBitLen, p.prng)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not sample S opening")
+	}
+	lambdaT, err := intSampleRangeSymmetricBits(p.lPrime+nHatBitLen, p.prng)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not sample T opening")
+	}
+	s, err := p.commit(num.Z().Zero(), lambdaS)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not compute simulated S")
+	}
+	t, err := p.commit(num.Z().Zero(), lambdaT)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not compute simulated T")
+	}
+
+	a, err := p.simulateA(statement, response, e)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not compute simulated A")
+	}
+	bx, err := p.simulateBX(statement, response, e)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not compute simulated Bx")
+	}
+	by, err := p.simulateBY(statement, response, e)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not compute simulated By")
+	}
+	eCommitment, err := p.simulatePedersen(response.z1, response.z3, s, e)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not compute simulated E")
+	}
+	fCommitment, err := p.simulatePedersen(response.z2, response.z4, t, e)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not compute simulated F")
+	}
+
+	commitment, err := NewCommitment(a, bx, by, eCommitment, fCommitment, s, t)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not create commitment")
+	}
+	return commitment, response, nil
+}
+
+// SpecialSoundness returns the protocol extraction parameter.
+func (*Protocol[G, B, S]) SpecialSoundness() uint {
+	return 2
+}
+
+// SoundnessError returns the challenge size in bits.
+func (p *Protocol[G, B, S]) SoundnessError() uint {
+	return uint(p.GetChallengeBytesLength() * 8)
+}
+
+// GetChallengeBytesLength returns the challenge size in bytes.
+func (*Protocol[G, B, S]) GetChallengeBytesLength() int {
+	return base.ComputationalSecurityBytesCeil
+}
+
+// ValidateStatement checks that the witness opens the public statement and lies in the configured ranges.
+func (p *Protocol[G, B, S]) ValidateStatement(statement *Statement[G, B, S], witness *Witness) error {
+	if statement == nil {
+		return ErrInvalidArgument.WithMessage("statement must not be nil")
+	}
+	if witness == nil {
+		return ErrInvalidArgument.WithMessage("witness must not be nil")
+	}
+	if err := p.validateStatement(statement); err != nil {
+		return errs.Wrap(err).WithMessage("invalid statement")
+	}
+	if err := p.validateWitness(statement, witness); err != nil {
+		return errs.Wrap(err).WithMessage("invalid witness")
+	}
+	return nil
+}
+
+func (p *Protocol[G, B, S]) sampleState(statement *Statement[G, B, S]) (*State, error) {
+	nHatBitLen := p.ringPedersenKey.Group().Modulus().TrueLen()
+
+	alpha, err := intSampleRangeSymmetricBits(p.l+p.epsilon, p.prng)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not sample alpha")
+	}
+	beta, err := intSampleRangeSymmetricBits(p.lPrime+p.epsilon, p.prng)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not sample beta")
+	}
+	gamma, err := intSampleRangeSymmetricBits(p.l+p.epsilon+nHatBitLen, p.prng)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not sample gamma")
+	}
+	m, err := intSampleRangeSymmetricBits(p.l+nHatBitLen, p.prng)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not sample m")
+	}
+	delta, err := intSampleRangeSymmetricBits(p.lPrime+p.epsilon+nHatBitLen, p.prng)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not sample delta")
+	}
+	mu, err := intSampleRangeSymmetricBits(p.lPrime+nHatBitLen, p.prng)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not sample mu")
+	}
+	r, err := statement.n0.SampleNonce(p.prng)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not sample r")
+	}
+	ry, err := statement.n1.SampleNonce(p.prng)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not sample ry")
+	}
+
+	state, err := NewState(alpha, beta, gamma, m, delta, mu, r, ry)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not create state")
+	}
+	return state, nil
+}
+
+func (p *Protocol[G, B, S]) computeCommitment(statement *Statement[G, B, S], witness *Witness, state *State) (*Commitment[G, B, S], error) {
+	betaN0, err := intToPlaintext(state.beta, statement.n0)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not create beta plaintext for N0")
+	}
+	encBetaN0, err := statement.n0.EncryptWithNonce(betaN0, state.r)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not encrypt beta under N0")
+	}
+	cAlpha, err := statement.n0.CiphertextScalarOp(statement.c, state.alpha)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not compute C^alpha")
+	}
+	a, err := statement.n0.CiphertextOp(cAlpha, encBetaN0)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not compute A")
+	}
+
+	alphaScalar, err := intToScalar(state.alpha, p.curve.ScalarField())
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not convert alpha to scalar")
+	}
+	bx := p.curve.ScalarBaseMul(alphaScalar)
+
+	betaN1, err := intToPlaintext(state.beta, statement.n1)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not create beta plaintext for N1")
+	}
+	by, err := statement.n1.EncryptWithNonce(betaN1, state.ry)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not compute By")
+	}
+
+	y := witness.y.Normalise()
+	s, err := p.commit(witness.x, state.m)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not compute S")
+	}
+	t, err := p.commit(y, state.mu)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not compute T")
+	}
+	e, err := p.commit(state.alpha, state.gamma)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not compute E")
+	}
+	f, err := p.commit(state.beta, state.delta)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not compute F")
+	}
+
+	commitment, err := NewCommitment(a, bx, by, e, f, s, t)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not create commitment")
+	}
+	return commitment, nil
+}
+
+func (*Protocol[G, B, S]) simulateA(statement *Statement[G, B, S], response *Response, e *num.Int) (*paillier.Ciphertext, error) {
+	cZ1, err := statement.n0.CiphertextScalarOp(statement.c, response.z1)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not compute C^z1")
+	}
+	z2N0, err := intToPlaintext(response.z2, statement.n0)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not create z2 plaintext for N0")
+	}
+	encZ2, err := statement.n0.EncryptWithNonce(z2N0, response.w)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not encrypt z2")
+	}
+	left, err := statement.n0.CiphertextOp(cZ1, encZ2)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not compute response side")
+	}
+	dNegE, err := statement.n0.CiphertextScalarOp(statement.d, e.Neg())
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not compute D^-e")
+	}
+	a, err := statement.n0.CiphertextOp(left, dNegE)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not compute A")
+	}
+	return a, nil
+}
+
+func (p *Protocol[G, B, S]) simulateBX(statement *Statement[G, B, S], response *Response, e *num.Int) (G, error) {
+	z1Scalar, err := intToScalar(response.z1, p.curve.ScalarField())
+	if err != nil {
+		return *new(G), errs.Wrap(err).WithMessage("could not convert z1 to scalar")
+	}
+	eNegScalar, err := intToScalar(e.Neg(), p.curve.ScalarField())
+	if err != nil {
+		return *new(G), errs.Wrap(err).WithMessage("could not convert challenge to scalar")
+	}
+	return p.curve.ScalarBaseMul(z1Scalar).Op(statement.x.ScalarOp(eNegScalar)), nil
+}
+
+func (*Protocol[G, B, S]) simulateBY(statement *Statement[G, B, S], response *Response, e *num.Int) (*paillier.Ciphertext, error) {
+	z2N1, err := intToPlaintext(response.z2, statement.n1)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not create z2 plaintext for N1")
+	}
+	left, err := statement.n1.EncryptWithNonce(z2N1, response.wy)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not encrypt z2")
+	}
+	yNegE, err := statement.n1.CiphertextScalarOp(statement.y, e.Neg())
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not compute Y^-e")
+	}
+	by, err := statement.n1.CiphertextOp(left, yNegE)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not compute By")
+	}
+	return by, nil
+}
+
+func (p *Protocol[G, B, S]) simulatePedersen(message, witness *num.Int, baseCommitment *intcom.Commitment, e *num.Int) (*intcom.Commitment, error) {
+	left, err := p.commit(message, witness)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not compute response commitment")
+	}
+	baseNegE, err := p.ringPedersenKey.CommitmentScalarOp(baseCommitment, e.Neg())
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not exponentiate base commitment")
+	}
+	out, err := p.ringPedersenKey.CommitmentOp(left, baseNegE)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not compute simulated commitment")
+	}
+	return out, nil
+}
+
+func (p *Protocol[G, B, S]) commit(messageValue, witnessValue *num.Int) (*intcom.Commitment, error) {
+	message, err := intcom.NewMessage(messageValue)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not create commitment message")
+	}
+	witness, err := intcom.NewWitness(witnessValue)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not create commitment witness")
+	}
+	commitment, err := p.ringPedersenKey.CommitWithWitness(message, witness)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not commit")
+	}
+	return commitment, nil
+}
+
+func (*Protocol[G, B, S]) mapChallenge(challenge sigma.ChallengeBytes) (*num.Int, error) {
+	if len(challenge) != base.ComputationalSecurityBytesCeil {
+		return nil, ErrInvalidArgument.WithMessage("invalid challenge length")
+	}
+	out, err := num.Z().FromTwosComplementBytesBE(challenge)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not parse challenge")
+	}
+	return out, nil
+}
+
+func (p *Protocol[G, B, S]) validateStatement(statement *Statement[G, B, S]) error {
+	if statement.n0.PlaintextGroup().Modulus().TrueLen()%8 != 0 || statement.n1.PlaintextGroup().Modulus().TrueLen()%8 != 0 {
+		return ErrValidationFailed.WithMessage("Paillier modulus bit lengths must be byte-aligned")
+	}
+	if err := signedBoundFitsPaillier(p.lPrime+p.epsilon, statement.n0); err != nil {
+		return errs.Wrap(err).WithMessage("invalid N0 modulus for y response range")
+	}
+	if err := signedBoundFitsPaillier(p.lPrime+p.epsilon, statement.n1); err != nil {
+		return errs.Wrap(err).WithMessage("invalid N1 modulus for y response range")
+	}
+	if !statement.n0.CiphertextGroup().Contains(statement.c.Value()) ||
+		!statement.n0.CiphertextGroup().Contains(statement.d.Value()) {
+
+		return ErrValidationFailed.WithMessage("C and D must be in the N0 ciphertext group")
+	}
+	if !statement.n1.CiphertextGroup().Contains(statement.y.Value()) {
+		return ErrValidationFailed.WithMessage("Y must be in the N1 ciphertext group")
+	}
+	if !p.curve.Contains(statement.x) {
+		return ErrValidationFailed.WithMessage("X must be in the curve group")
+	}
+	return nil
+}
+
+func (p *Protocol[G, B, S]) validateWitness(statement *Statement[G, B, S], witness *Witness) error {
+	if !intInSignedBitRange(witness.x, p.l) {
+		return ErrValidationFailed.WithMessage("x is out of range")
+	}
+	y := witness.y.Normalise()
+	if !intInSignedBitRange(y, p.lPrime) {
+		return ErrValidationFailed.WithMessage("y is out of range")
+	}
+	if !statement.n1.PlaintextGroup().Contains(witness.y.Value()) {
+		return ErrValidationFailed.WithMessage("y is not in the N1 plaintext group")
+	}
+	if !statement.n0.NonceGroup().Contains(witness.rho.Value()) {
+		return ErrValidationFailed.WithMessage("rho is not in the N0 nonce group")
+	}
+	if !statement.n1.NonceGroup().Contains(witness.rhoY.Value()) {
+		return ErrValidationFailed.WithMessage("rhoY is not in the N1 nonce group")
+	}
+
+	xScalar, err := intToScalar(witness.x, p.curve.ScalarField())
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not convert x to scalar")
+	}
+	if !p.curve.ScalarBaseMul(xScalar).Equal(statement.x) {
+		return ErrValidationFailed.WithMessage("x does not open X")
+	}
+	yCheck, err := statement.n1.EncryptWithNonce(witness.y, witness.rhoY)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not recompute Y")
+	}
+	if !statement.y.Equal(yCheck) {
+		return ErrValidationFailed.WithMessage("witness does not open Y")
+	}
+	cX, err := statement.n0.CiphertextScalarOp(statement.c, witness.x)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not compute C^x")
+	}
+	yN0, err := intToPlaintext(y, statement.n0)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not create y plaintext for N0")
+	}
+	encY, err := statement.n0.EncryptWithNonce(yN0, witness.rho)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not encrypt y under N0")
+	}
+	dCheck, err := statement.n0.CiphertextOp(cX, encY)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not recompute D")
+	}
+	if !statement.d.Equal(dCheck) {
+		return ErrValidationFailed.WithMessage("witness does not open D")
+	}
+	return nil
+}
+
+func (p *Protocol[G, B, S]) validateCommitment(statement *Statement[G, B, S], commitment *Commitment[G, B, S]) error {
+	if !statement.n0.CiphertextGroup().Contains(commitment.a.Value()) {
+		return ErrValidationFailed.WithMessage("A must be in the N0 ciphertext group")
+	}
+	if !statement.n1.CiphertextGroup().Contains(commitment.by.Value()) {
+		return ErrValidationFailed.WithMessage("By must be in the N1 ciphertext group")
+	}
+	if !p.curve.Contains(commitment.bx) {
+		return ErrValidationFailed.WithMessage("Bx must be in the curve group")
+	}
+	group := p.ringPedersenKey.CommitmentGroup()
+	for _, elem := range []*intcom.Commitment{commitment.e, commitment.f, commitment.s, commitment.t} {
+		if !group.Contains(elem.Value()) {
+			return ErrValidationFailed.WithMessage("Pedersen commitment must be in the commitment group")
+		}
+	}
+	return nil
+}
+
+func (*Protocol[G, B, S]) validateResponse(statement *Statement[G, B, S], response *Response) error {
+	if !statement.n0.NonceGroup().Contains(response.w.Value()) {
+		return ErrValidationFailed.WithMessage("w must be in the N0 nonce group")
+	}
+	if !statement.n1.NonceGroup().Contains(response.wy.Value()) {
+		return ErrValidationFailed.WithMessage("wy must be in the N1 nonce group")
+	}
+	return nil
+}

--- a/pkg/proofs/cggmp21/affg/protocol_test.go
+++ b/pkg/proofs/cggmp21/affg/protocol_test.go
@@ -1,0 +1,110 @@
+package affg_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bronlabs/bron-crypto/pkg/base/curves/k256"
+	"github.com/bronlabs/bron-crypto/pkg/base/nt/num"
+	"github.com/bronlabs/bron-crypto/pkg/base/prng/pcg"
+	"github.com/bronlabs/bron-crypto/pkg/commitments/intcom"
+	"github.com/bronlabs/bron-crypto/pkg/encryption/paillier"
+	ntu "github.com/bronlabs/bron-crypto/pkg/network/testutils"
+	"github.com/bronlabs/bron-crypto/pkg/proofs/cggmp21/affg"
+)
+
+const (
+	testL       = 256
+	testLPrime  = 1280
+	testEpsilon = 512
+	testKeyBits = 2048
+)
+
+func TestProtocolHappyPathAndSimulator(t *testing.T) {
+	t.Parallel()
+
+	prng := pcg.NewRandomised()
+	protocol, statement, witness := sampleProtocolStatementAndWitness(t, prng)
+	challenge := make([]byte, protocol.GetChallengeBytesLength())
+	_, err := io.ReadFull(prng, challenge)
+	require.NoError(t, err)
+
+	require.NoError(t, protocol.ValidateStatement(statement, witness))
+
+	commitment, state, err := protocol.ComputeProverCommitment(statement, witness)
+	require.NoError(t, err)
+	response, err := protocol.ComputeProverResponse(statement, witness, commitment, state, challenge)
+	require.NoError(t, err)
+	require.NoError(t, protocol.Verify(statement, commitment, challenge, response))
+
+	roundTrippedStatement := ntu.CBORRoundTrip(t, statement)
+	require.Equal(t, statement.Bytes(), roundTrippedStatement.Bytes())
+	roundTrippedCommitment := ntu.CBORRoundTrip(t, commitment)
+	require.Equal(t, commitment.Bytes(), roundTrippedCommitment.Bytes())
+	roundTrippedResponse := ntu.CBORRoundTrip(t, response)
+	require.Equal(t, response.Bytes(), roundTrippedResponse.Bytes())
+	require.NoError(t, protocol.Verify(roundTrippedStatement, roundTrippedCommitment, challenge, roundTrippedResponse))
+
+	simulatedCommitment, simulatedResponse, err := protocol.RunSimulator(statement, challenge)
+	require.NoError(t, err)
+	require.NoError(t, protocol.Verify(statement, simulatedCommitment, challenge, simulatedResponse))
+}
+
+func sampleProtocolStatementAndWitness(
+	t *testing.T,
+	prng io.Reader,
+) (*affg.Protocol[*k256.Point, *k256.BaseFieldElement, *k256.Scalar], *affg.Statement[*k256.Point, *k256.BaseFieldElement, *k256.Scalar], *affg.Witness) {
+	t.Helper()
+
+	ringPedersenKey, err := intcom.SampleCommitmentKey(testKeyBits, prng)
+	require.NoError(t, err)
+	n0SecretKey, err := paillier.SampleSecretKey(testKeyBits, prng)
+	require.NoError(t, err)
+	n1SecretKey, err := paillier.SampleSecretKey(testKeyBits, prng)
+	require.NoError(t, err)
+	n0 := n0SecretKey.Public()
+	n1 := n1SecretKey.Public()
+
+	curve := k256.NewCurve()
+	protocol, err := affg.NewProtocol(ringPedersenKey, testL, testLPrime, testEpsilon, curve, prng)
+	require.NoError(t, err)
+
+	xInt := num.Z().FromInt64(42)
+	xScalar, err := curve.ScalarField().FromBytesBEReduce(xInt.Big().Bytes())
+	require.NoError(t, err)
+	xPoint := curve.ScalarBaseMul(xScalar)
+
+	yInt := num.Z().FromInt64(-17)
+	yN1, err := paillier.NewPlaintextSymmetric(yInt, n1.PlaintextGroup().Modulus())
+	require.NoError(t, err)
+	rhoY, err := n1.SampleNonce(prng)
+	require.NoError(t, err)
+	yCiphertext, err := n1.EncryptWithNonce(yN1, rhoY)
+	require.NoError(t, err)
+
+	cPlaintext, err := paillier.NewPlaintextSymmetric(num.Z().FromInt64(123), n0.PlaintextGroup().Modulus())
+	require.NoError(t, err)
+	cNonce, err := n0.SampleNonce(prng)
+	require.NoError(t, err)
+	c, err := n0.EncryptWithNonce(cPlaintext, cNonce)
+	require.NoError(t, err)
+
+	rho, err := n0.SampleNonce(prng)
+	require.NoError(t, err)
+	yN0, err := paillier.NewPlaintextSymmetric(yInt, n0.PlaintextGroup().Modulus())
+	require.NoError(t, err)
+	encryptedY, err := n0.EncryptWithNonce(yN0, rho)
+	require.NoError(t, err)
+	cX, err := n0.CiphertextScalarOp(c, xInt)
+	require.NoError(t, err)
+	d, err := n0.CiphertextOp(cX, encryptedY)
+	require.NoError(t, err)
+
+	statement, err := affg.NewStatement(n0, n1, c, d, yCiphertext, xPoint)
+	require.NoError(t, err)
+	witness, err := affg.NewWitness(xInt, yN1, rho, rhoY)
+	require.NoError(t, err)
+	return protocol, statement, witness
+}

--- a/pkg/proofs/cggmp21/affgstar/README.md
+++ b/pkg/proofs/cggmp21/affgstar/README.md
@@ -82,7 +82,7 @@ $$
 
 - `Statement` stores `N0`, `N1`, `C`, `D`, `Y`, and `X`.
 - `Witness` stores `x` as `*num.Int`, `y` as a Paillier plaintext under `N1`, and the two Paillier nonces.
-- The challenge is `base.ComputationalSecurityBytesCeil` bytes interpreted as `base.ComputationalSecurityBits` challenge bits.
+- The challenge is `base.ComputationalSecurityBytesCeil` bytes interpreted as `base.ComputationalSecurityBits` challenge bits. This intentionally fixes the repetition count to 128 bits rather than exposing `kappa` as a separate protocol parameter.
 - Signed integer samples use byte-aligned two's-complement sampling over exactly the requested byte length.
 - The repeated Paillier encryptions use `encryption.EncryptManyWithNonces`.
 - `ValidateStatement` checks that the witness opens `X`, `Y`, and `D`, and that `x` and `y` satisfy the configured narrow ranges.

--- a/pkg/proofs/cggmp21/affgstar/README.md
+++ b/pkg/proofs/cggmp21/affgstar/README.md
@@ -1,0 +1,96 @@
+# CGGMP21 Setup-Less Paillier Affine Operation with Group Commitment
+
+This package implements the sigma protocol Pi aff-g* from Appendix A.5, Figure 27 of CGGMP21.
+
+The statement is `(G, g, N0, N1, C, D, Y, X)`. The witness is `(x, y, rho, rhoY)` such that:
+
+$$
+x \in \pm 2^\ell,\quad y \in \pm 2^{\ell'},\quad X = g^x,
+$$
+
+$$
+Y = (1+N_1)^y \rho_Y^{N_1} \bmod N_1^2,
+$$
+
+and
+
+$$
+D = C^x (1+N_0)^y \rho^{N_0} \bmod N_0^2.
+$$
+
+The implementation exposes `ell` as `l`, `ell'` as `lPrime`, and the statistical slack as `epsilon`. It fixes the protocol repetition count to `kappa = base.ComputationalSecurityBits`.
+
+## Protocol
+
+For each `j` in `[kappa]`, the prover samples:
+
+$$
+\alpha_j \leftarrow \pm 2^{\ell+\epsilon},\quad
+\beta_j \leftarrow \pm 2^{\ell'+\epsilon},
+$$
+
+$$
+r_j \leftarrow Z^*_{N_0},\quad s_j \leftarrow Z^*_{N_1}.
+$$
+
+It sends:
+
+$$
+A_j = C^{\alpha_j}(1+N_0)^{\beta_j}r_j^{N_0} \bmod N_0^2,
+$$
+
+$$
+R_j = g^{\alpha_j},
+$$
+
+$$
+B_j = (1+N_1)^{\beta_j}s_j^{N_1} \bmod N_1^2.
+$$
+
+The verifier replies with challenge bits `e_j in {0,1}`. The response is:
+
+$$
+z_j = \alpha_j + e_jx,\quad z'_j = \beta_j + e_jy,
+$$
+
+$$
+w_j = r_j\rho^{e_j} \bmod N_0,\quad
+\lambda_j = s_j\rho_Y^{e_j} \bmod N_1.
+$$
+
+The verifier checks, for every `j`:
+
+$$
+C^{z_j}(1+N_0)^{z'_j}w_j^{N_0} = A_jD^{e_j} \bmod N_0^2,
+$$
+
+$$
+g^{z_j} = R_jX^{e_j},
+$$
+
+$$
+(1+N_1)^{z'_j}\lambda_j^{N_1} = B_jY^{e_j} \bmod N_1^2,
+$$
+
+and the widened ranges:
+
+$$
+z_j \in \pm 2^{\ell+\epsilon},\quad z'_j \in \pm 2^{\ell'+\epsilon}.
+$$
+
+## Implementation Notes
+
+- `Statement` stores `N0`, `N1`, `C`, `D`, `Y`, and `X`.
+- `Witness` stores `x` as `*num.Int`, `y` as a Paillier plaintext under `N1`, and the two Paillier nonces.
+- The challenge is `base.ComputationalSecurityBytesCeil` bytes interpreted as `base.ComputationalSecurityBits` challenge bits.
+- Signed integer samples use byte-aligned two's-complement sampling over exactly the requested byte length.
+- The repeated Paillier encryptions use `encryption.EncryptManyWithNonces`.
+- `ValidateStatement` checks that the witness opens `X`, `Y`, and `D`, and that `x` and `y` satisfy the configured narrow ranges.
+- Statement validation checks that both Paillier moduli can encode the widened `zPrime` range `lPrime + epsilon` in their symmetric plaintext intervals.
+
+## Reference
+
+<!-- paper: docs/papers/2021-060_20241021_172019.pdf [Appendix A.5, Figure 27] -->
+- Canetti, Gennaro, Goldfeder, Makriyannis, Peled.
+  [UC Non-Interactive, Proactive, Threshold ECDSA with Identifiable Aborts](https://eprint.iacr.org/2021/060),
+  Appendix A.5, Figure 27.

--- a/pkg/proofs/cggmp21/affgstar/affgstar.go
+++ b/pkg/proofs/cggmp21/affgstar/affgstar.go
@@ -1,0 +1,322 @@
+package affgstar
+
+import (
+	"encoding/binary"
+
+	"github.com/bronlabs/errs-go/errs"
+
+	"github.com/bronlabs/bron-crypto/pkg/base/algebra"
+	"github.com/bronlabs/bron-crypto/pkg/base/curves"
+	"github.com/bronlabs/bron-crypto/pkg/base/nt/num"
+	"github.com/bronlabs/bron-crypto/pkg/base/serde"
+	"github.com/bronlabs/bron-crypto/pkg/base/utils"
+	"github.com/bronlabs/bron-crypto/pkg/base/utils/sliceutils"
+	"github.com/bronlabs/bron-crypto/pkg/encryption/paillier"
+	"github.com/bronlabs/bron-crypto/pkg/proofs/sigma"
+)
+
+const (
+	// Name identifies the CGGMP21 setup-less Paillier affine operation with group commitment proof.
+	Name sigma.Name = "CGGMP21_SETUPLESS_PAILLIER_AFFINE_OP_WITH_GROUP_COMMITMENT"
+)
+
+// Statement is the public input (N0, N1, C, D, Y, X) for CGGMP21 Figure 27.
+type Statement[G curves.Point[G, B, S], B algebra.PrimeFieldElement[B], S algebra.PrimeFieldElement[S]] struct {
+	n0 *paillier.PublicKey
+	n1 *paillier.PublicKey
+	c  *paillier.Ciphertext
+	d  *paillier.Ciphertext
+	y  *paillier.Ciphertext
+	x  G
+}
+
+type statementDTO[G curves.Point[G, B, S], B algebra.PrimeFieldElement[B], S algebra.PrimeFieldElement[S]] struct {
+	N0 *paillier.PublicKey  `cbor:"n0"`
+	N1 *paillier.PublicKey  `cbor:"n1"`
+	C  *paillier.Ciphertext `cbor:"c"`
+	D  *paillier.Ciphertext `cbor:"d"`
+	Y  *paillier.Ciphertext `cbor:"y"`
+	X  G                    `cbor:"x"`
+}
+
+// NewStatement constructs a setup-less Paillier affine statement.
+func NewStatement[G curves.Point[G, B, S], B algebra.PrimeFieldElement[B], S algebra.PrimeFieldElement[S]](
+	n0 *paillier.PublicKey,
+	n1 *paillier.PublicKey,
+	c *paillier.Ciphertext,
+	d *paillier.Ciphertext,
+	y *paillier.Ciphertext,
+	x G,
+) (*Statement[G, B, S], error) {
+	if n0 == nil || n1 == nil || c == nil || d == nil || y == nil || utils.IsNil(x) {
+		return nil, ErrInvalidArgument.WithMessage("statement values must not be nil")
+	}
+	return &Statement[G, B, S]{
+		n0: n0,
+		n1: n1,
+		c:  c,
+		d:  d,
+		y:  y,
+		x:  x,
+	}, nil
+}
+
+// MarshalCBOR serialises the statement to CBOR format.
+func (s *Statement[G, B, S]) MarshalCBOR() ([]byte, error) {
+	dto := &statementDTO[G, B, S]{
+		N0: s.n0,
+		N1: s.n1,
+		C:  s.c,
+		D:  s.d,
+		Y:  s.y,
+		X:  s.x,
+	}
+	out, err := serde.MarshalCBOR(dto)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not marshal statement to CBOR")
+	}
+	return out, nil
+}
+
+// UnmarshalCBOR deserialises the statement from CBOR format.
+func (s *Statement[G, B, S]) UnmarshalCBOR(data []byte) error {
+	dto, err := serde.UnmarshalCBOR[*statementDTO[G, B, S]](data)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not unmarshal statement from CBOR")
+	}
+	if dto == nil {
+		return ErrInvalidArgument.WithMessage("statement DTO must not be nil")
+	}
+	statement, err := NewStatement(dto.N0, dto.N1, dto.C, dto.D, dto.Y, dto.X)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("invalid statement data")
+	}
+	*s = *statement
+	return nil
+}
+
+// Bytes serialises the statement for transcript binding.
+func (s *Statement[G, B, S]) Bytes() []byte {
+	out := binary.LittleEndian.AppendUint64(nil, 6)
+	out = sliceutils.AppendLengthPrefixed(out, s.n0.Group().N().Bytes())
+	out = sliceutils.AppendLengthPrefixed(out, s.n1.Group().N().Bytes())
+	out = sliceutils.AppendLengthPrefixed(out, s.c.Bytes())
+	out = sliceutils.AppendLengthPrefixed(out, s.d.Bytes())
+	out = sliceutils.AppendLengthPrefixed(out, s.y.Bytes())
+	out = sliceutils.AppendLengthPrefixed(out, s.x.Bytes())
+	return out
+}
+
+// Witness is the secret input (x, y, rho, rhoY) from CGGMP21 Figure 27.
+type Witness struct {
+	x    *num.Int
+	y    *paillier.Plaintext
+	rho  *paillier.Nonce
+	rhoY *paillier.Nonce
+}
+
+// NewWitness constructs a setup-less Paillier affine witness.
+func NewWitness(x *num.Int, y *paillier.Plaintext, rho, rhoY *paillier.Nonce) (*Witness, error) {
+	if x == nil || y == nil || rho == nil || rhoY == nil {
+		return nil, ErrInvalidArgument.WithMessage("witness values must not be nil")
+	}
+	return &Witness{
+		x:    x.Clone(),
+		y:    y,
+		rho:  rho,
+		rhoY: rhoY,
+	}, nil
+}
+
+// State stores the prover's per-repetition sampled randomness between sigma rounds.
+type State struct {
+	alpha []*num.Int
+	beta  []*num.Int
+	r     []*paillier.Nonce
+	s     []*paillier.Nonce
+}
+
+// NewState constructs the prover state retained between sigma rounds.
+func NewState(alpha, beta []*num.Int, r, s []*paillier.Nonce) (*State, error) {
+	if err := validateIntSlice("state alpha", alpha); err != nil {
+		return nil, err
+	}
+	if err := validateIntSlice("state beta", beta); err != nil {
+		return nil, err
+	}
+	if err := validateNonceSlice("state r", r); err != nil {
+		return nil, err
+	}
+	if err := validateNonceSlice("state s", s); err != nil {
+		return nil, err
+	}
+	return &State{
+		alpha: alpha,
+		beta:  beta,
+		r:     r,
+		s:     s,
+	}, nil
+}
+
+// Commitment is the prover's first message (A_j, B_j, R_j) for each repetition.
+type Commitment[G curves.Point[G, B, S], B algebra.PrimeFieldElement[B], S algebra.PrimeFieldElement[S]] struct {
+	a []*paillier.Ciphertext
+	b []*paillier.Ciphertext
+	r []G
+}
+
+type commitmentDTO[G curves.Point[G, B, S], B algebra.PrimeFieldElement[B], S algebra.PrimeFieldElement[S]] struct {
+	A []*paillier.Ciphertext `cbor:"a"`
+	B []*paillier.Ciphertext `cbor:"b"`
+	R []G                    `cbor:"r"`
+}
+
+// NewCommitment constructs a setup-less Paillier affine commitment.
+func NewCommitment[G curves.Point[G, B, S], B algebra.PrimeFieldElement[B], S algebra.PrimeFieldElement[S]](
+	a []*paillier.Ciphertext,
+	b []*paillier.Ciphertext,
+	r []G,
+) (*Commitment[G, B, S], error) {
+	if err := validateCiphertextSlice("commitment A", a); err != nil {
+		return nil, err
+	}
+	if err := validateCiphertextSlice("commitment B", b); err != nil {
+		return nil, err
+	}
+	if len(r) != challengeBitsLength {
+		return nil, ErrInvalidArgument.WithMessage("commitment R must have length %d", challengeBitsLength)
+	}
+	for _, elem := range r {
+		if utils.IsNil(elem) {
+			return nil, ErrInvalidArgument.WithMessage("commitment R values must not be nil")
+		}
+	}
+	return &Commitment[G, B, S]{
+		a: a,
+		b: b,
+		r: r,
+	}, nil
+}
+
+// MarshalCBOR serialises the commitment to CBOR format.
+func (c *Commitment[G, B, S]) MarshalCBOR() ([]byte, error) {
+	dto := &commitmentDTO[G, B, S]{
+		A: c.a,
+		B: c.b,
+		R: c.r,
+	}
+	out, err := serde.MarshalCBOR(dto)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not marshal commitment to CBOR")
+	}
+	return out, nil
+}
+
+// UnmarshalCBOR deserialises the commitment from CBOR format.
+func (c *Commitment[G, B, S]) UnmarshalCBOR(data []byte) error {
+	dto, err := serde.UnmarshalCBOR[*commitmentDTO[G, B, S]](data)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not unmarshal commitment from CBOR")
+	}
+	if dto == nil {
+		return ErrInvalidArgument.WithMessage("commitment DTO must not be nil")
+	}
+	commitment, err := NewCommitment(dto.A, dto.B, dto.R)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("invalid commitment data")
+	}
+	*c = *commitment
+	return nil
+}
+
+// Bytes serialises the commitment for transcript binding.
+func (c *Commitment[G, B, S]) Bytes() []byte {
+	out := binary.LittleEndian.AppendUint64(nil, uint64(len(c.a)))
+	for i := range c.a {
+		out = sliceutils.AppendLengthPrefixed(out, c.a[i].Bytes())
+		out = sliceutils.AppendLengthPrefixed(out, c.b[i].Bytes())
+		out = sliceutils.AppendLengthPrefixed(out, c.r[i].Bytes())
+	}
+	return out
+}
+
+// Response is the prover's final message (z_j, z'_j, w_j, lambda_j) for each repetition.
+type Response struct {
+	z      []*num.Int
+	zPrime []*num.Int
+	w      []*paillier.Nonce
+	lambda []*paillier.Nonce
+}
+
+type responseDTO struct {
+	Z      []*num.Int        `cbor:"z"`
+	ZPrime []*num.Int        `cbor:"zPrime"`
+	W      []*paillier.Nonce `cbor:"w"`
+	Lambda []*paillier.Nonce `cbor:"lambda"`
+}
+
+// NewResponse constructs a setup-less Paillier affine response.
+func NewResponse(z, zPrime []*num.Int, w, lambda []*paillier.Nonce) (*Response, error) {
+	if err := validateIntSlice("response z", z); err != nil {
+		return nil, err
+	}
+	if err := validateIntSlice("response zPrime", zPrime); err != nil {
+		return nil, err
+	}
+	if err := validateNonceSlice("response w", w); err != nil {
+		return nil, err
+	}
+	if err := validateNonceSlice("response lambda", lambda); err != nil {
+		return nil, err
+	}
+	return &Response{
+		z:      z,
+		zPrime: zPrime,
+		w:      w,
+		lambda: lambda,
+	}, nil
+}
+
+// MarshalCBOR serialises the response to CBOR format.
+func (r *Response) MarshalCBOR() ([]byte, error) {
+	dto := &responseDTO{
+		Z:      r.z,
+		ZPrime: r.zPrime,
+		W:      r.w,
+		Lambda: r.lambda,
+	}
+	out, err := serde.MarshalCBOR(dto)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not marshal response to CBOR")
+	}
+	return out, nil
+}
+
+// UnmarshalCBOR deserialises the response from CBOR format.
+func (r *Response) UnmarshalCBOR(data []byte) error {
+	dto, err := serde.UnmarshalCBOR[*responseDTO](data)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not unmarshal response from CBOR")
+	}
+	if dto == nil {
+		return ErrInvalidArgument.WithMessage("response DTO must not be nil")
+	}
+	response, err := NewResponse(dto.Z, dto.ZPrime, dto.W, dto.Lambda)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("invalid response data")
+	}
+	*r = *response
+	return nil
+}
+
+// Bytes serialises the response for transcript binding.
+func (r *Response) Bytes() []byte {
+	out := binary.LittleEndian.AppendUint64(nil, uint64(len(r.z)))
+	for i := range r.z {
+		out = sliceutils.AppendLengthPrefixed(out, r.z[i].Bytes())
+		out = sliceutils.AppendLengthPrefixed(out, r.zPrime[i].Bytes())
+		out = sliceutils.AppendLengthPrefixed(out, r.w[i].Bytes())
+		out = sliceutils.AppendLengthPrefixed(out, r.lambda[i].Bytes())
+	}
+	return out
+}

--- a/pkg/proofs/cggmp21/affgstar/affgstar_smoke_test.go
+++ b/pkg/proofs/cggmp21/affgstar/affgstar_smoke_test.go
@@ -1,0 +1,19 @@
+package affgstar_test
+
+import (
+	"github.com/bronlabs/bron-crypto/pkg/base/algebra"
+	"github.com/bronlabs/bron-crypto/pkg/base/curves"
+	"github.com/bronlabs/bron-crypto/pkg/proofs/cggmp21/affgstar"
+	"github.com/bronlabs/bron-crypto/pkg/proofs/sigma"
+	"github.com/bronlabs/bron-crypto/pkg/signatures/ecdsa"
+)
+
+func _[G curves.Point[G, B, S], B algebra.PrimeFieldElement[B], S algebra.PrimeFieldElement[S]](_ ecdsa.Curve[G, B, S]) {
+	var _ sigma.Statement = (*affgstar.Statement[G, B, S])(nil)
+	var _ sigma.Witness = (*affgstar.Witness)(nil)
+	var _ sigma.State = (*affgstar.State)(nil)
+	var _ sigma.Commitment = (*affgstar.Commitment[G, B, S])(nil)
+	var _ sigma.Response = (*affgstar.Response)(nil)
+
+	var _ sigma.Protocol[*affgstar.Statement[G, B, S], *affgstar.Witness, *affgstar.Commitment[G, B, S], *affgstar.State, *affgstar.Response] = (*affgstar.Protocol[G, B, S])(nil)
+}

--- a/pkg/proofs/cggmp21/affgstar/doc.go
+++ b/pkg/proofs/cggmp21/affgstar/doc.go
@@ -1,3 +1,7 @@
 // Package affgstar implements CGGMP21 Figure 27, the setup-less Paillier
 // affine operation sigma protocol with a group commitment.
+//
+// CBOR unmarshalling validates local structure and nested type constructors.
+// Contextual checks that depend on protocol parameters or statement/witness
+// relations are performed by Protocol.ValidateStatement and Protocol.Verify.
 package affgstar

--- a/pkg/proofs/cggmp21/affgstar/doc.go
+++ b/pkg/proofs/cggmp21/affgstar/doc.go
@@ -1,0 +1,3 @@
+// Package affgstar implements CGGMP21 Figure 27, the setup-less Paillier
+// affine operation sigma protocol with a group commitment.
+package affgstar

--- a/pkg/proofs/cggmp21/affgstar/errors.go
+++ b/pkg/proofs/cggmp21/affgstar/errors.go
@@ -1,0 +1,12 @@
+package affgstar
+
+import "github.com/bronlabs/errs-go/errs"
+
+var (
+	// ErrInvalidArgument indicates missing or inconsistent protocol inputs.
+	ErrInvalidArgument = errs.New("invalid argument")
+	// ErrValidationFailed indicates that a statement/witness pair is malformed or inconsistent.
+	ErrValidationFailed = errs.New("validation failed")
+	// ErrVerificationFailed indicates a failed sigma-protocol verification.
+	ErrVerificationFailed = errs.New("verification failed")
+)

--- a/pkg/proofs/cggmp21/affgstar/helpers.go
+++ b/pkg/proofs/cggmp21/affgstar/helpers.go
@@ -1,0 +1,119 @@
+package affgstar
+
+import (
+	"io"
+	"math/big"
+
+	"github.com/bronlabs/errs-go/errs"
+
+	"github.com/bronlabs/bron-crypto/pkg/base/algebra"
+	"github.com/bronlabs/bron-crypto/pkg/base/nt/num"
+	"github.com/bronlabs/bron-crypto/pkg/encryption/paillier"
+)
+
+func intSampleRangeSymmetricBits(bitLen int, prngReader io.Reader) (*num.Int, error) {
+	buf := make([]byte, bitLen/8)
+	if _, err := io.ReadFull(prngReader, buf); err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not sample integer bytes")
+	}
+
+	out, err := num.Z().FromTwosComplementBytesBE(buf)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not parse sampled integer")
+	}
+	return out, nil
+}
+
+func intInSignedBitRange(v *num.Int, bitLen int) bool {
+	return v.Abs().TrueLen() <= bitLen
+}
+
+func intToPlaintext(v *num.Int, paillierKey *paillier.PublicKey) (*paillier.Plaintext, error) {
+	out, err := paillier.NewPlaintextSymmetric(v, paillierKey.PlaintextGroup().Modulus())
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not create signed Paillier plaintext")
+	}
+	return out, nil
+}
+
+func intsToPlaintexts(values []*num.Int, paillierKey *paillier.PublicKey) ([]*paillier.Plaintext, error) {
+	out := make([]*paillier.Plaintext, len(values))
+	for i, v := range values {
+		plaintext, err := intToPlaintext(v, paillierKey)
+		if err != nil {
+			return nil, errs.Wrap(err).WithMessage("could not create plaintext at index %d", i)
+		}
+		out[i] = plaintext
+	}
+	return out, nil
+}
+
+func intToScalar[S algebra.PrimeFieldElement[S]](v *num.Int, scalarField algebra.PrimeField[S]) (S, error) {
+	var nilS S
+	if v == nil {
+		return nilS, ErrInvalidArgument.WithMessage("integer must not be nil")
+	}
+	if scalarField == nil {
+		return nilS, ErrInvalidArgument.WithMessage("scalar field must not be nil")
+	}
+
+	modulus := scalarField.Order().Big()
+	reduced := new(big.Int).Mod(v.Big(), modulus)
+	if reduced.Sign() == 0 {
+		return scalarField.FromUint64(0), nil
+	}
+	out, err := scalarField.FromBytesBEReduce(reduced.Bytes())
+	if err != nil {
+		return nilS, errs.Wrap(err).WithMessage("could not reduce integer to scalar")
+	}
+	return out, nil
+}
+
+func signedBoundFitsPaillier(bits int, paillierKey *paillier.PublicKey) error {
+	if paillierKey == nil {
+		return ErrInvalidArgument.WithMessage("Paillier key must not be nil")
+	}
+	modulus := paillierKey.PlaintextGroup().Modulus()
+	bound := num.Z().One().Lsh(uint(bits))
+	halfModulus := modulus.Rsh(1).Lift()
+	if !bound.IsLessThanOrEqual(halfModulus) {
+		return ErrValidationFailed.WithMessage("2^%d must fit in the Paillier symmetric plaintext range", bits)
+	}
+	return nil
+}
+
+func validateIntSlice(name string, values []*num.Int) error {
+	if len(values) != challengeBitsLength {
+		return ErrInvalidArgument.WithMessage("%s must have length %d", name, challengeBitsLength)
+	}
+	for _, elem := range values {
+		if elem == nil {
+			return ErrInvalidArgument.WithMessage("%s values must not be nil", name)
+		}
+	}
+	return nil
+}
+
+func validateNonceSlice(name string, values []*paillier.Nonce) error {
+	if len(values) != challengeBitsLength {
+		return ErrInvalidArgument.WithMessage("%s must have length %d", name, challengeBitsLength)
+	}
+	for _, elem := range values {
+		if elem == nil {
+			return ErrInvalidArgument.WithMessage("%s values must not be nil", name)
+		}
+	}
+	return nil
+}
+
+func validateCiphertextSlice(name string, values []*paillier.Ciphertext) error {
+	if len(values) != challengeBitsLength {
+		return ErrInvalidArgument.WithMessage("%s must have length %d", name, challengeBitsLength)
+	}
+	for _, elem := range values {
+		if elem == nil {
+			return ErrInvalidArgument.WithMessage("%s values must not be nil", name)
+		}
+	}
+	return nil
+}

--- a/pkg/proofs/cggmp21/affgstar/helpers.go
+++ b/pkg/proofs/cggmp21/affgstar/helpers.go
@@ -25,7 +25,7 @@ func intSampleRangeSymmetricBits(bitLen int, prngReader io.Reader) (*num.Int, er
 }
 
 func intInSignedBitRange(v *num.Int, bitLen int) bool {
-	return v.Abs().TrueLen() <= bitLen
+	return v.Abs().TrueLen() < bitLen
 }
 
 func intToPlaintext(v *num.Int, paillierKey *paillier.PublicKey) (*paillier.Plaintext, error) {

--- a/pkg/proofs/cggmp21/affgstar/protocol.go
+++ b/pkg/proofs/cggmp21/affgstar/protocol.go
@@ -1,0 +1,649 @@
+package affgstar
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/bronlabs/errs-go/errs"
+
+	"github.com/bronlabs/bron-crypto/pkg/base"
+	"github.com/bronlabs/bron-crypto/pkg/base/algebra"
+	"github.com/bronlabs/bron-crypto/pkg/base/curves"
+	"github.com/bronlabs/bron-crypto/pkg/base/nt/num"
+	"github.com/bronlabs/bron-crypto/pkg/base/utils"
+	"github.com/bronlabs/bron-crypto/pkg/encryption"
+	"github.com/bronlabs/bron-crypto/pkg/encryption/paillier"
+	"github.com/bronlabs/bron-crypto/pkg/proofs/sigma"
+	"github.com/bronlabs/bron-crypto/pkg/signatures/ecdsa"
+)
+
+const (
+	challengeBitsLength  = base.ComputationalSecurityBits
+	challengeBytesLength = base.ComputationalSecurityBytesCeil
+)
+
+// Protocol implements the CGGMP21 setup-less Paillier affine operation with group commitment proof from Figure 27.
+type Protocol[G curves.Point[G, B, S], B algebra.PrimeFieldElement[B], S algebra.PrimeFieldElement[S]] struct {
+	name    sigma.Name
+	l       int
+	lPrime  int
+	epsilon int
+	curve   ecdsa.Curve[G, B, S]
+	prng    io.Reader
+}
+
+// NewProtocol constructs the CGGMP21 Figure 27 setup-less Paillier affine sigma protocol.
+func NewProtocol[G curves.Point[G, B, S], B algebra.PrimeFieldElement[B], S algebra.PrimeFieldElement[S]](l, lPrime, epsilon int, curve ecdsa.Curve[G, B, S], prng io.Reader) (*Protocol[G, B, S], error) {
+	if prng == nil {
+		return nil, ErrInvalidArgument.WithMessage("prng is required")
+	}
+	if utils.IsNil(curve) {
+		return nil, ErrInvalidArgument.WithMessage("curve is required")
+	}
+	if (l <= 0) || (l%8 != 0) {
+		return nil, ErrInvalidArgument.WithMessage("l must be a multiple of 8")
+	}
+	if (lPrime <= 0) || (lPrime%8 != 0) {
+		return nil, ErrInvalidArgument.WithMessage("lPrime must be a multiple of 8")
+	}
+	if (epsilon <= 0) || (epsilon%8 != 0) {
+		return nil, ErrInvalidArgument.WithMessage("epsilon must be a multiple of 8")
+	}
+
+	k := curve.ScalarField().BitLen()
+	if k < base.ComputationalSecurityBits {
+		return nil, ErrInvalidArgument.WithMessage("invalid curve")
+	}
+	if l < k {
+		return nil, ErrInvalidArgument.WithMessage("invalid l")
+	}
+	if epsilon < l+k {
+		return nil, ErrInvalidArgument.WithMessage("invalid epsilon")
+	}
+	if lPrime < l+epsilon+2*l {
+		return nil, ErrInvalidArgument.WithMessage("invalid lPrime")
+	}
+
+	name := sigma.Name(fmt.Sprintf(
+		"%s_L=%d_LPRIME=%d_EPS=%d_CURVE=%s_KAPPA=%d",
+		Name,
+		l,
+		lPrime,
+		epsilon,
+		curve.Name(),
+		challengeBitsLength,
+	))
+	p := &Protocol[G, B, S]{
+		name:    name,
+		l:       l,
+		lPrime:  lPrime,
+		epsilon: epsilon,
+		curve:   curve,
+		prng:    prng,
+	}
+	return p, nil
+}
+
+// Name returns the protocol identifier, including public parameters.
+func (p *Protocol[G, B, S]) Name() sigma.Name {
+	return p.name
+}
+
+// ComputeProverCommitment generates the prover's first message.
+func (p *Protocol[G, B, S]) ComputeProverCommitment(statement *Statement[G, B, S], witness *Witness) (*Commitment[G, B, S], *State, error) {
+	if statement == nil {
+		return nil, nil, ErrInvalidArgument.WithMessage("statement must not be nil")
+	}
+	if witness == nil {
+		return nil, nil, ErrInvalidArgument.WithMessage("witness must not be nil")
+	}
+	if err := p.validateStatement(statement); err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("invalid statement")
+	}
+
+	state, err := p.sampleState(statement)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not sample prover state")
+	}
+	commitment, err := p.computeCommitment(statement, state)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not compute prover commitment")
+	}
+	return commitment, state, nil
+}
+
+// ComputeProverResponse generates the prover response for a fixed challenge.
+func (p *Protocol[G, B, S]) ComputeProverResponse(statement *Statement[G, B, S], witness *Witness, commitment *Commitment[G, B, S], state *State, challenge sigma.ChallengeBytes) (*Response, error) {
+	if statement == nil {
+		return nil, ErrInvalidArgument.WithMessage("statement must not be nil")
+	}
+	if witness == nil {
+		return nil, ErrInvalidArgument.WithMessage("witness must not be nil")
+	}
+	if commitment == nil {
+		return nil, ErrInvalidArgument.WithMessage("commitment must not be nil")
+	}
+	if state == nil {
+		return nil, ErrInvalidArgument.WithMessage("state must not be nil")
+	}
+	if err := p.validateStatement(statement); err != nil {
+		return nil, errs.Wrap(err).WithMessage("invalid statement")
+	}
+	bits, err := p.mapChallenge(challenge)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("invalid challenge")
+	}
+
+	y := witness.y.Normalise()
+	z := make([]*num.Int, challengeBitsLength)
+	zPrime := make([]*num.Int, challengeBitsLength)
+	w := make([]*paillier.Nonce, challengeBitsLength)
+	lambda := make([]*paillier.Nonce, challengeBitsLength)
+	for i, bit := range bits {
+		e := bitToInt(bit)
+		z[i] = state.alpha[i].Add(e.Mul(witness.x))
+		zPrime[i] = state.beta[i].Add(e.Mul(y))
+		rhoE, err := statement.n0.NonceScalarOp(witness.rho, e)
+		if err != nil {
+			return nil, errs.Wrap(err).WithMessage("could not compute rho^e at index %d", i)
+		}
+		w[i], err = statement.n0.NonceOp(state.r[i], rhoE)
+		if err != nil {
+			return nil, errs.Wrap(err).WithMessage("could not compute w at index %d", i)
+		}
+		rhoYE, err := statement.n1.NonceScalarOp(witness.rhoY, e)
+		if err != nil {
+			return nil, errs.Wrap(err).WithMessage("could not compute rhoY^e at index %d", i)
+		}
+		lambda[i], err = statement.n1.NonceOp(state.s[i], rhoYE)
+		if err != nil {
+			return nil, errs.Wrap(err).WithMessage("could not compute lambda at index %d", i)
+		}
+	}
+
+	response, err := NewResponse(z, zPrime, w, lambda)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not create response")
+	}
+	return response, nil
+}
+
+// Verify checks the Figure 27 equality checks and widened response ranges.
+func (p *Protocol[G, B, S]) Verify(statement *Statement[G, B, S], commitment *Commitment[G, B, S], challenge sigma.ChallengeBytes, response *Response) error {
+	if statement == nil {
+		return ErrInvalidArgument.WithMessage("statement must not be nil")
+	}
+	if commitment == nil {
+		return ErrInvalidArgument.WithMessage("commitment must not be nil")
+	}
+	if response == nil {
+		return ErrInvalidArgument.WithMessage("response must not be nil")
+	}
+	if err := p.validateStatement(statement); err != nil {
+		return errs.Wrap(err).WithMessage("invalid statement")
+	}
+	if err := p.validateCommitment(statement, commitment); err != nil {
+		return errs.Wrap(err).WithMessage("invalid commitment")
+	}
+	if err := p.validateResponse(statement, response); err != nil {
+		return errs.Wrap(err).WithMessage("invalid response")
+	}
+	bits, err := p.mapChallenge(challenge)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("invalid challenge")
+	}
+
+	for i := range bits {
+		if !intInSignedBitRange(response.z[i], p.l+p.epsilon) {
+			return ErrVerificationFailed.WithMessage("z is out of range at index %d", i)
+		}
+		if !intInSignedBitRange(response.zPrime[i], p.lPrime+p.epsilon) {
+			return ErrVerificationFailed.WithMessage("zPrime is out of range at index %d", i)
+		}
+	}
+
+	zPrimeN0, err := intsToPlaintexts(response.zPrime, statement.n0)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not create zPrime plaintexts for N0")
+	}
+	encZPrimeN0, err := encryption.EncryptManyWithNonces(zPrimeN0, statement.n0, response.w)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not encrypt zPrime values under N0")
+	}
+	zPrimeN1, err := intsToPlaintexts(response.zPrime, statement.n1)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not create zPrime plaintexts for N1")
+	}
+	encZPrimeN1, err := encryption.EncryptManyWithNonces(zPrimeN1, statement.n1, response.lambda)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not encrypt zPrime values under N1")
+	}
+
+	for i, bit := range bits {
+		if err := p.verifyN0(statement, commitment, response, encZPrimeN0[i], bit, i); err != nil {
+			return errs.Wrap(err).WithMessage("N0 equality failed at index %d", i)
+		}
+		if err := p.verifyCurve(statement, commitment, response, bit, i); err != nil {
+			return errs.Wrap(err).WithMessage("curve equality failed at index %d", i)
+		}
+		if err := p.verifyN1(statement, commitment, encZPrimeN1[i], bit, i); err != nil {
+			return errs.Wrap(err).WithMessage("N1 equality failed at index %d", i)
+		}
+	}
+	return nil
+}
+
+// RunSimulator creates an honest-verifier simulated transcript for a fixed challenge.
+func (p *Protocol[G, B, S]) RunSimulator(statement *Statement[G, B, S], challenge sigma.ChallengeBytes) (*Commitment[G, B, S], *Response, error) {
+	if statement == nil {
+		return nil, nil, ErrInvalidArgument.WithMessage("statement must not be nil")
+	}
+	if err := p.validateStatement(statement); err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("invalid statement")
+	}
+	bits, err := p.mapChallenge(challenge)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("invalid challenge")
+	}
+
+	z := make([]*num.Int, challengeBitsLength)
+	zPrime := make([]*num.Int, challengeBitsLength)
+	w := make([]*paillier.Nonce, challengeBitsLength)
+	lambda := make([]*paillier.Nonce, challengeBitsLength)
+	for i := range challengeBitsLength {
+		z[i], err = intSampleRangeSymmetricBits(p.l+p.epsilon, p.prng)
+		if err != nil {
+			return nil, nil, errs.Wrap(err).WithMessage("could not sample z at index %d", i)
+		}
+		zPrime[i], err = intSampleRangeSymmetricBits(p.lPrime+p.epsilon, p.prng)
+		if err != nil {
+			return nil, nil, errs.Wrap(err).WithMessage("could not sample zPrime at index %d", i)
+		}
+		w[i], err = statement.n0.SampleNonce(p.prng)
+		if err != nil {
+			return nil, nil, errs.Wrap(err).WithMessage("could not sample w at index %d", i)
+		}
+		lambda[i], err = statement.n1.SampleNonce(p.prng)
+		if err != nil {
+			return nil, nil, errs.Wrap(err).WithMessage("could not sample lambda at index %d", i)
+		}
+	}
+	response, err := NewResponse(z, zPrime, w, lambda)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not create response")
+	}
+
+	a, err := p.simulateA(statement, response, bits)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not compute simulated A")
+	}
+	r, err := p.simulateR(statement, response, bits)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not compute simulated R")
+	}
+	b, err := p.simulateB(statement, response, bits)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not compute simulated B")
+	}
+	commitment, err := NewCommitment(a, b, r)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not create commitment")
+	}
+	return commitment, response, nil
+}
+
+// SpecialSoundness returns the protocol extraction parameter.
+func (*Protocol[G, B, S]) SpecialSoundness() uint {
+	return 2
+}
+
+// SoundnessError returns the kappa-bit soundness error.
+func (*Protocol[G, B, S]) SoundnessError() uint {
+	return uint(challengeBitsLength)
+}
+
+// GetChallengeBytesLength returns the challenge size in bytes.
+func (*Protocol[G, B, S]) GetChallengeBytesLength() int {
+	return challengeBytesLength
+}
+
+// ValidateStatement checks that the witness opens the public statement and lies in the configured ranges.
+func (p *Protocol[G, B, S]) ValidateStatement(statement *Statement[G, B, S], witness *Witness) error {
+	if statement == nil {
+		return ErrInvalidArgument.WithMessage("statement must not be nil")
+	}
+	if witness == nil {
+		return ErrInvalidArgument.WithMessage("witness must not be nil")
+	}
+	if err := p.validateStatement(statement); err != nil {
+		return errs.Wrap(err).WithMessage("invalid statement")
+	}
+	if err := p.validateWitness(statement, witness); err != nil {
+		return errs.Wrap(err).WithMessage("invalid witness")
+	}
+	return nil
+}
+
+func (p *Protocol[G, B, S]) sampleState(statement *Statement[G, B, S]) (*State, error) {
+	alpha := make([]*num.Int, challengeBitsLength)
+	beta := make([]*num.Int, challengeBitsLength)
+	r := make([]*paillier.Nonce, challengeBitsLength)
+	s := make([]*paillier.Nonce, challengeBitsLength)
+	for i := range challengeBitsLength {
+		var err error
+		alpha[i], err = intSampleRangeSymmetricBits(p.l+p.epsilon, p.prng)
+		if err != nil {
+			return nil, errs.Wrap(err).WithMessage("could not sample alpha at index %d", i)
+		}
+		beta[i], err = intSampleRangeSymmetricBits(p.lPrime+p.epsilon, p.prng)
+		if err != nil {
+			return nil, errs.Wrap(err).WithMessage("could not sample beta at index %d", i)
+		}
+		r[i], err = statement.n0.SampleNonce(p.prng)
+		if err != nil {
+			return nil, errs.Wrap(err).WithMessage("could not sample r at index %d", i)
+		}
+		s[i], err = statement.n1.SampleNonce(p.prng)
+		if err != nil {
+			return nil, errs.Wrap(err).WithMessage("could not sample s at index %d", i)
+		}
+	}
+
+	state, err := NewState(alpha, beta, r, s)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not create state")
+	}
+	return state, nil
+}
+
+func (p *Protocol[G, B, S]) computeCommitment(statement *Statement[G, B, S], state *State) (*Commitment[G, B, S], error) {
+	betaN0, err := intsToPlaintexts(state.beta, statement.n0)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not create beta plaintexts for N0")
+	}
+	encBetaN0, err := encryption.EncryptManyWithNonces(betaN0, statement.n0, state.r)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not encrypt beta values under N0")
+	}
+
+	a := make([]*paillier.Ciphertext, challengeBitsLength)
+	r := make([]G, challengeBitsLength)
+	for i := range challengeBitsLength {
+		cAlpha, err := statement.n0.CiphertextScalarOp(statement.c, state.alpha[i])
+		if err != nil {
+			return nil, errs.Wrap(err).WithMessage("could not compute C^alpha at index %d", i)
+		}
+		a[i], err = statement.n0.CiphertextOp(cAlpha, encBetaN0[i])
+		if err != nil {
+			return nil, errs.Wrap(err).WithMessage("could not compute A at index %d", i)
+		}
+		alphaScalar, err := intToScalar(state.alpha[i], p.curve.ScalarField())
+		if err != nil {
+			return nil, errs.Wrap(err).WithMessage("could not convert alpha to scalar at index %d", i)
+		}
+		r[i] = p.curve.ScalarBaseMul(alphaScalar)
+	}
+
+	betaN1, err := intsToPlaintexts(state.beta, statement.n1)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not create beta plaintexts for N1")
+	}
+	b, err := encryption.EncryptManyWithNonces(betaN1, statement.n1, state.s)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not encrypt beta values under N1")
+	}
+
+	commitment, err := NewCommitment(a, b, r)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not create commitment")
+	}
+	return commitment, nil
+}
+
+func (*Protocol[G, B, S]) verifyN0(statement *Statement[G, B, S], commitment *Commitment[G, B, S], response *Response, encZPrime *paillier.Ciphertext, bit byte, index int) error {
+	cZ, err := statement.n0.CiphertextScalarOp(statement.c, response.z[index])
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not compute C^z")
+	}
+	left, err := statement.n0.CiphertextOp(cZ, encZPrime)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not compute N0 left side")
+	}
+	right := commitment.a[index]
+	if bit == 1 {
+		right, err = statement.n0.CiphertextOp(right, statement.d)
+		if err != nil {
+			return errs.Wrap(err).WithMessage("could not compute N0 right side")
+		}
+	}
+	if !left.Equal(right) {
+		return ErrVerificationFailed.WithMessage("N0 equality check failed")
+	}
+	return nil
+}
+
+func (p *Protocol[G, B, S]) verifyCurve(statement *Statement[G, B, S], commitment *Commitment[G, B, S], response *Response, bit byte, index int) error {
+	zScalar, err := intToScalar(response.z[index], p.curve.ScalarField())
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not convert z to scalar")
+	}
+	left := p.curve.ScalarBaseMul(zScalar)
+	right := commitment.r[index]
+	if bit == 1 {
+		right = right.Op(statement.x)
+	}
+	if !left.Equal(right) {
+		return ErrVerificationFailed.WithMessage("curve equality check failed")
+	}
+	return nil
+}
+
+func (*Protocol[G, B, S]) verifyN1(statement *Statement[G, B, S], commitment *Commitment[G, B, S], encZPrime *paillier.Ciphertext, bit byte, index int) error {
+	right := commitment.b[index]
+	if bit == 1 {
+		var err error
+		right, err = statement.n1.CiphertextOp(right, statement.y)
+		if err != nil {
+			return errs.Wrap(err).WithMessage("could not compute N1 right side")
+		}
+	}
+	if !encZPrime.Equal(right) {
+		return ErrVerificationFailed.WithMessage("N1 equality check failed")
+	}
+	return nil
+}
+
+func (*Protocol[G, B, S]) simulateA(statement *Statement[G, B, S], response *Response, bits []byte) ([]*paillier.Ciphertext, error) {
+	zPrimeN0, err := intsToPlaintexts(response.zPrime, statement.n0)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not create zPrime plaintexts for N0")
+	}
+	encZPrime, err := encryption.EncryptManyWithNonces(zPrimeN0, statement.n0, response.w)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not encrypt zPrime values under N0")
+	}
+
+	out := make([]*paillier.Ciphertext, challengeBitsLength)
+	for i, bit := range bits {
+		cZ, err := statement.n0.CiphertextScalarOp(statement.c, response.z[i])
+		if err != nil {
+			return nil, errs.Wrap(err).WithMessage("could not compute C^z at index %d", i)
+		}
+		left, err := statement.n0.CiphertextOp(cZ, encZPrime[i])
+		if err != nil {
+			return nil, errs.Wrap(err).WithMessage("could not compute response side at index %d", i)
+		}
+		dNegE, err := statement.n0.CiphertextScalarOp(statement.d, bitToInt(bit).Neg())
+		if err != nil {
+			return nil, errs.Wrap(err).WithMessage("could not compute D^-e at index %d", i)
+		}
+		out[i], err = statement.n0.CiphertextOp(left, dNegE)
+		if err != nil {
+			return nil, errs.Wrap(err).WithMessage("could not compute A at index %d", i)
+		}
+	}
+	return out, nil
+}
+
+func (p *Protocol[G, B, S]) simulateR(statement *Statement[G, B, S], response *Response, bits []byte) ([]G, error) {
+	out := make([]G, challengeBitsLength)
+	for i, bit := range bits {
+		zScalar, err := intToScalar(response.z[i], p.curve.ScalarField())
+		if err != nil {
+			return nil, errs.Wrap(err).WithMessage("could not convert z to scalar at index %d", i)
+		}
+		eNegScalar, err := intToScalar(bitToInt(bit).Neg(), p.curve.ScalarField())
+		if err != nil {
+			return nil, errs.Wrap(err).WithMessage("could not convert challenge to scalar at index %d", i)
+		}
+		out[i] = p.curve.ScalarBaseMul(zScalar).Op(statement.x.ScalarOp(eNegScalar))
+	}
+	return out, nil
+}
+
+func (*Protocol[G, B, S]) simulateB(statement *Statement[G, B, S], response *Response, bits []byte) ([]*paillier.Ciphertext, error) {
+	zPrimeN1, err := intsToPlaintexts(response.zPrime, statement.n1)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not create zPrime plaintexts for N1")
+	}
+	left, err := encryption.EncryptManyWithNonces(zPrimeN1, statement.n1, response.lambda)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not encrypt zPrime values under N1")
+	}
+
+	out := make([]*paillier.Ciphertext, challengeBitsLength)
+	for i, bit := range bits {
+		yNegE, err := statement.n1.CiphertextScalarOp(statement.y, bitToInt(bit).Neg())
+		if err != nil {
+			return nil, errs.Wrap(err).WithMessage("could not compute Y^-e at index %d", i)
+		}
+		out[i], err = statement.n1.CiphertextOp(left[i], yNegE)
+		if err != nil {
+			return nil, errs.Wrap(err).WithMessage("could not compute B at index %d", i)
+		}
+	}
+	return out, nil
+}
+
+func (*Protocol[G, B, S]) mapChallenge(challenge sigma.ChallengeBytes) ([]byte, error) {
+	if len(challenge) != challengeBytesLength {
+		return nil, ErrInvalidArgument.WithMessage("invalid challenge length")
+	}
+	out := make([]byte, challengeBitsLength)
+	for i := range challengeBitsLength {
+		out[i] = (challenge[i/8] >> uint(7-(i%8))) & 1
+	}
+	return out, nil
+}
+
+func (p *Protocol[G, B, S]) validateStatement(statement *Statement[G, B, S]) error {
+	if statement.n0.PlaintextGroup().Modulus().TrueLen()%8 != 0 || statement.n1.PlaintextGroup().Modulus().TrueLen()%8 != 0 {
+		return ErrValidationFailed.WithMessage("Paillier modulus bit lengths must be byte-aligned")
+	}
+	if err := signedBoundFitsPaillier(p.lPrime+p.epsilon, statement.n0); err != nil {
+		return errs.Wrap(err).WithMessage("invalid N0 modulus for y response range")
+	}
+	if err := signedBoundFitsPaillier(p.lPrime+p.epsilon, statement.n1); err != nil {
+		return errs.Wrap(err).WithMessage("invalid N1 modulus for y response range")
+	}
+	if !statement.n0.CiphertextGroup().Contains(statement.c.Value()) ||
+		!statement.n0.CiphertextGroup().Contains(statement.d.Value()) {
+
+		return ErrValidationFailed.WithMessage("C and D must be in the N0 ciphertext group")
+	}
+	if !statement.n1.CiphertextGroup().Contains(statement.y.Value()) {
+		return ErrValidationFailed.WithMessage("Y must be in the N1 ciphertext group")
+	}
+	if !p.curve.Contains(statement.x) {
+		return ErrValidationFailed.WithMessage("X must be in the curve group")
+	}
+	return nil
+}
+
+func (p *Protocol[G, B, S]) validateWitness(statement *Statement[G, B, S], witness *Witness) error {
+	if !intInSignedBitRange(witness.x, p.l) {
+		return ErrValidationFailed.WithMessage("x is out of range")
+	}
+	y := witness.y.Normalise()
+	if !intInSignedBitRange(y, p.lPrime) {
+		return ErrValidationFailed.WithMessage("y is out of range")
+	}
+	if !statement.n1.PlaintextGroup().Contains(witness.y.Value()) {
+		return ErrValidationFailed.WithMessage("y is not in the N1 plaintext group")
+	}
+	if !statement.n0.NonceGroup().Contains(witness.rho.Value()) {
+		return ErrValidationFailed.WithMessage("rho is not in the N0 nonce group")
+	}
+	if !statement.n1.NonceGroup().Contains(witness.rhoY.Value()) {
+		return ErrValidationFailed.WithMessage("rhoY is not in the N1 nonce group")
+	}
+
+	xScalar, err := intToScalar(witness.x, p.curve.ScalarField())
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not convert x to scalar")
+	}
+	if !p.curve.ScalarBaseMul(xScalar).Equal(statement.x) {
+		return ErrValidationFailed.WithMessage("x does not open X")
+	}
+	yCheck, err := statement.n1.EncryptWithNonce(witness.y, witness.rhoY)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not recompute Y")
+	}
+	if !statement.y.Equal(yCheck) {
+		return ErrValidationFailed.WithMessage("witness does not open Y")
+	}
+	cX, err := statement.n0.CiphertextScalarOp(statement.c, witness.x)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not compute C^x")
+	}
+	yN0, err := intToPlaintext(y, statement.n0)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not create y plaintext for N0")
+	}
+	encY, err := statement.n0.EncryptWithNonce(yN0, witness.rho)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not encrypt y under N0")
+	}
+	dCheck, err := statement.n0.CiphertextOp(cX, encY)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not recompute D")
+	}
+	if !statement.d.Equal(dCheck) {
+		return ErrValidationFailed.WithMessage("witness does not open D")
+	}
+	return nil
+}
+
+func (p *Protocol[G, B, S]) validateCommitment(statement *Statement[G, B, S], commitment *Commitment[G, B, S]) error {
+	for i := range challengeBitsLength {
+		if !statement.n0.CiphertextGroup().Contains(commitment.a[i].Value()) {
+			return ErrValidationFailed.WithMessage("A must be in the N0 ciphertext group at index %d", i)
+		}
+		if !statement.n1.CiphertextGroup().Contains(commitment.b[i].Value()) {
+			return ErrValidationFailed.WithMessage("B must be in the N1 ciphertext group at index %d", i)
+		}
+		if !p.curve.Contains(commitment.r[i]) {
+			return ErrValidationFailed.WithMessage("R must be in the curve group at index %d", i)
+		}
+	}
+	return nil
+}
+
+func (*Protocol[G, B, S]) validateResponse(statement *Statement[G, B, S], response *Response) error {
+	for i := range challengeBitsLength {
+		if !statement.n0.NonceGroup().Contains(response.w[i].Value()) {
+			return ErrValidationFailed.WithMessage("w must be in the N0 nonce group at index %d", i)
+		}
+		if !statement.n1.NonceGroup().Contains(response.lambda[i].Value()) {
+			return ErrValidationFailed.WithMessage("lambda must be in the N1 nonce group at index %d", i)
+		}
+	}
+	return nil
+}
+
+func bitToInt(bit byte) *num.Int {
+	if bit == 0 {
+		return num.Z().Zero()
+	}
+	return num.Z().One()
+}

--- a/pkg/proofs/cggmp21/affgstar/protocol_test.go
+++ b/pkg/proofs/cggmp21/affgstar/protocol_test.go
@@ -1,0 +1,107 @@
+package affgstar_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bronlabs/bron-crypto/pkg/base/curves/k256"
+	"github.com/bronlabs/bron-crypto/pkg/base/nt/num"
+	"github.com/bronlabs/bron-crypto/pkg/base/prng/pcg"
+	"github.com/bronlabs/bron-crypto/pkg/encryption/paillier"
+	ntu "github.com/bronlabs/bron-crypto/pkg/network/testutils"
+	"github.com/bronlabs/bron-crypto/pkg/proofs/cggmp21/affgstar"
+)
+
+const (
+	testL       = 256
+	testLPrime  = 1280
+	testEpsilon = 512
+	testKeyBits = 2048
+)
+
+func TestProtocolHappyPathAndSimulator(t *testing.T) {
+	t.Parallel()
+
+	prng := pcg.NewRandomised()
+	protocol, statement, witness := sampleProtocolStatementAndWitness(t, prng)
+	challenge := make([]byte, protocol.GetChallengeBytesLength())
+	_, err := io.ReadFull(prng, challenge)
+	require.NoError(t, err)
+
+	require.NoError(t, protocol.ValidateStatement(statement, witness))
+
+	commitment, state, err := protocol.ComputeProverCommitment(statement, witness)
+	require.NoError(t, err)
+	response, err := protocol.ComputeProverResponse(statement, witness, commitment, state, challenge)
+	require.NoError(t, err)
+	require.NoError(t, protocol.Verify(statement, commitment, challenge, response))
+
+	roundTrippedStatement := ntu.CBORRoundTrip(t, statement)
+	require.Equal(t, statement.Bytes(), roundTrippedStatement.Bytes())
+	roundTrippedCommitment := ntu.CBORRoundTrip(t, commitment)
+	require.Equal(t, commitment.Bytes(), roundTrippedCommitment.Bytes())
+	roundTrippedResponse := ntu.CBORRoundTrip(t, response)
+	require.Equal(t, response.Bytes(), roundTrippedResponse.Bytes())
+	require.NoError(t, protocol.Verify(roundTrippedStatement, roundTrippedCommitment, challenge, roundTrippedResponse))
+
+	simulatedCommitment, simulatedResponse, err := protocol.RunSimulator(statement, challenge)
+	require.NoError(t, err)
+	require.NoError(t, protocol.Verify(statement, simulatedCommitment, challenge, simulatedResponse))
+}
+
+func sampleProtocolStatementAndWitness(
+	t *testing.T,
+	prng io.Reader,
+) (*affgstar.Protocol[*k256.Point, *k256.BaseFieldElement, *k256.Scalar], *affgstar.Statement[*k256.Point, *k256.BaseFieldElement, *k256.Scalar], *affgstar.Witness) {
+	t.Helper()
+
+	n0SecretKey, err := paillier.SampleSecretKey(testKeyBits, prng)
+	require.NoError(t, err)
+	n1SecretKey, err := paillier.SampleSecretKey(testKeyBits, prng)
+	require.NoError(t, err)
+	n0 := n0SecretKey.Public()
+	n1 := n1SecretKey.Public()
+
+	curve := k256.NewCurve()
+	protocol, err := affgstar.NewProtocol(testL, testLPrime, testEpsilon, curve, prng)
+	require.NoError(t, err)
+
+	xInt := num.Z().FromInt64(42)
+	xScalar, err := curve.ScalarField().FromBytesBEReduce(xInt.Big().Bytes())
+	require.NoError(t, err)
+	xPoint := curve.ScalarBaseMul(xScalar)
+
+	yInt := num.Z().FromInt64(-17)
+	yN1, err := paillier.NewPlaintextSymmetric(yInt, n1.PlaintextGroup().Modulus())
+	require.NoError(t, err)
+	rhoY, err := n1.SampleNonce(prng)
+	require.NoError(t, err)
+	yCiphertext, err := n1.EncryptWithNonce(yN1, rhoY)
+	require.NoError(t, err)
+
+	cPlaintext, err := paillier.NewPlaintextSymmetric(num.Z().FromInt64(123), n0.PlaintextGroup().Modulus())
+	require.NoError(t, err)
+	cNonce, err := n0.SampleNonce(prng)
+	require.NoError(t, err)
+	c, err := n0.EncryptWithNonce(cPlaintext, cNonce)
+	require.NoError(t, err)
+
+	rho, err := n0.SampleNonce(prng)
+	require.NoError(t, err)
+	yN0, err := paillier.NewPlaintextSymmetric(yInt, n0.PlaintextGroup().Modulus())
+	require.NoError(t, err)
+	encryptedY, err := n0.EncryptWithNonce(yN0, rho)
+	require.NoError(t, err)
+	cX, err := n0.CiphertextScalarOp(c, xInt)
+	require.NoError(t, err)
+	d, err := n0.CiphertextOp(cX, encryptedY)
+	require.NoError(t, err)
+
+	statement, err := affgstar.NewStatement(n0, n1, c, d, yCiphertext, xPoint)
+	require.NoError(t, err)
+	witness, err := affgstar.NewWitness(xInt, yN1, rho, rhoY)
+	require.NoError(t, err)
+	return protocol, statement, witness
+}

--- a/pkg/proofs/cggmp21/blummod/protocol.go
+++ b/pkg/proofs/cggmp21/blummod/protocol.go
@@ -224,6 +224,9 @@ func (p *Protocol) Verify(statement *Statement, commitment *Commitment, challeng
 	}
 	n := statement.publicKey.PlaintextGroup().Modulus()
 	for i, item := range &response.items {
+		if !nonceGroup.Contains(ys[i].Value()) {
+			return ErrVerificationFailed.WithMessage("challenge element is not in the nonce group")
+		}
 		if !nonceGroup.Contains(item.x.Value()) || !nonceGroup.Contains(item.z.Value()) {
 			return ErrVerificationFailed.WithMessage("response values are not in the nonce group")
 		}

--- a/pkg/proofs/cggmp21/blummod/protocol_internal_test.go
+++ b/pkg/proofs/cggmp21/blummod/protocol_internal_test.go
@@ -6,8 +6,13 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/bronlabs/bron-crypto/pkg/base/datastructures/hashset"
 	"github.com/bronlabs/bron-crypto/pkg/base/prng/pcg"
 	"github.com/bronlabs/bron-crypto/pkg/encryption/paillier"
+	"github.com/bronlabs/bron-crypto/pkg/mpc/session"
+	session_testutils "github.com/bronlabs/bron-crypto/pkg/mpc/session/testutils"
+	"github.com/bronlabs/bron-crypto/pkg/mpc/sharing"
+	"github.com/bronlabs/bron-crypto/pkg/proofs/sigma/compiler/fiatshamir"
 )
 
 const internalTestKeyLen = 512
@@ -80,4 +85,59 @@ func TestVerifyRejectsTamperedResponse(t *testing.T) {
 
 	err = protocol.Verify(statement, commitment, challenge, tamperedResponse)
 	require.ErrorIs(t, err, ErrVerificationFailed)
+}
+
+func TestFiatShamirChallengeBindsCommitment(t *testing.T) {
+	t.Parallel()
+
+	prng := pcg.NewRandomised()
+	sk, err := paillier.SampleBlumSecretKey(internalTestKeyLen, prng)
+	require.NoError(t, err)
+	statement, err := NewStatement(sk.Public())
+	require.NoError(t, err)
+	witness, err := NewWitness(sk)
+	require.NoError(t, err)
+	protocol, err := NewProtocol(prng)
+	require.NoError(t, err)
+
+	commitment, state, err := protocol.ComputeProverCommitment(statement, witness)
+	require.NoError(t, err)
+	otherCommitment, _, err := protocol.ComputeProverCommitment(statement, witness)
+	require.NoError(t, err)
+	require.NotEqual(t, commitment.Bytes(), otherCommitment.Bytes())
+
+	const proverID = 1
+	const verifierID = 2
+	quorum := hashset.NewComparable[sharing.ID](proverID, verifierID).Freeze()
+	ctxs := session_testutils.MakeRandomContexts(t, quorum, prng)
+
+	challenge := deriveFiatShamirChallenge(t, protocol, statement, commitment, ctxs[proverID])
+	otherChallenge := deriveFiatShamirChallenge(t, protocol, statement, otherCommitment, ctxs[verifierID])
+	require.NotEqual(t, challenge, otherChallenge)
+
+	response, err := protocol.ComputeProverResponse(statement, witness, commitment, state, challenge)
+	require.NoError(t, err)
+	require.NoError(t, protocol.Verify(statement, commitment, challenge, response))
+	require.ErrorIs(t, protocol.Verify(statement, otherCommitment, challenge, response), ErrVerificationFailed)
+}
+
+func deriveFiatShamirChallenge(
+	t *testing.T,
+	protocol *Protocol,
+	statement *Statement,
+	commitment *Commitment,
+	ctx *session.Context,
+) []byte {
+	t.Helper()
+
+	compiler, err := fiatshamir.NewCompiler(protocol)
+	require.NoError(t, err)
+	_, err = compiler.NewProver(ctx)
+	require.NoError(t, err)
+
+	ctx.Transcript().AppendBytes("statementLabel-", statement.Bytes())
+	ctx.Transcript().AppendBytes("commitmentLabel-", commitment.Bytes())
+	challenge, err := ctx.Transcript().ExtractBytes("challengeLabel-", uint(protocol.GetChallengeBytesLength()))
+	require.NoError(t, err)
+	return challenge
 }

--- a/pkg/proofs/cggmp21/dec/README.md
+++ b/pkg/proofs/cggmp21/dec/README.md
@@ -1,0 +1,80 @@
+# CGGMP21 Paillier Special Decryption in the Exponent
+
+This package implements the sigma protocol Pi dec from Appendix A.6, Figure 28 of CGGMP21.
+
+The statement is `(G, g, N0, K, X, D, S)`. The witness is `(x, y, rho)` such that:
+
+$$
+x \in \pm 2^\ell,\quad y \in \pm 2^{\ell'},\quad X = g^x,\quad S = g^y,
+$$
+
+and
+
+$$
+(1+N_0)^y \rho^{N_0} = K^x D \bmod N_0^2.
+$$
+
+The implementation exposes `ell` as `l`, `ell'` as `lPrime`, and the statistical slack as `epsilon`. It fixes the protocol repetition count to `kappa = base.ComputationalSecurityBits`.
+
+## Protocol
+
+For each `j` in `[kappa]`, the prover samples:
+
+$$
+\alpha_j \leftarrow \pm 2^{\ell+\epsilon},\quad
+\beta_j \leftarrow \pm 2^{\ell'+\epsilon},\quad
+r_j \leftarrow Z^*_{N_0}.
+$$
+
+It sends:
+
+$$
+A_j = K^{-\alpha_j}(1+N_0)^{\beta_j}r_j^{N_0} \bmod N_0^2,
+$$
+
+$$
+B_j = g^{\beta_j},\quad C_j = g^{\alpha_j}.
+$$
+
+The verifier replies with challenge bits `e_j in {0,1}`. The response is:
+
+$$
+z_j = \alpha_j + e_jx,\quad w_j = \beta_j + e_jy,
+$$
+
+$$
+\nu_j = r_j\rho^{e_j} \bmod N_0.
+$$
+
+The verifier checks, for every `j`:
+
+$$
+(1+N_0)^{w_j}\nu_j^{N_0}K^{-z_j} = A_jD^{e_j} \bmod N_0^2,
+$$
+
+$$
+g^{z_j} = C_jX^{e_j},\quad g^{w_j} = B_jS^{e_j},
+$$
+
+and the widened ranges:
+
+$$
+z_j \in \pm 2^{\ell+\epsilon},\quad w_j \in \pm 2^{\ell'+\epsilon}.
+$$
+
+## Implementation Notes
+
+- `Statement` stores `N0`, `K`, `X`, `D`, and `S`.
+- `Witness` stores `x` and `y` as `*num.Int`, and the Paillier nonce `rho`.
+- The challenge is `base.ComputationalSecurityBytesCeil` bytes interpreted as `base.ComputationalSecurityBits` challenge bits.
+- Signed integer samples use byte-aligned two's-complement sampling over exactly the requested byte length.
+- The repeated Paillier encryptions use `encryption.EncryptManyWithNonces`.
+- `ValidateStatement` checks that the witness opens `X`, `S`, and the Paillier relation, and that `x` and `y` satisfy the configured narrow ranges.
+- Statement validation checks that the Paillier modulus can encode the widened `w` range `lPrime + epsilon` in its symmetric plaintext interval.
+
+## Reference
+
+<!-- paper: docs/papers/2021-060_20241021_172019.pdf [Appendix A.6, Figure 28] -->
+- Canetti, Gennaro, Goldfeder, Makriyannis, Peled.
+  [UC Non-Interactive, Proactive, Threshold ECDSA with Identifiable Aborts](https://eprint.iacr.org/2021/060),
+  Appendix A.6, Figure 28.

--- a/pkg/proofs/cggmp21/dec/README.md
+++ b/pkg/proofs/cggmp21/dec/README.md
@@ -66,7 +66,7 @@ $$
 
 - `Statement` stores `N0`, `K`, `X`, `D`, and `S`.
 - `Witness` stores `x` and `y` as `*num.Int`, and the Paillier nonce `rho`.
-- The challenge is `base.ComputationalSecurityBytesCeil` bytes interpreted as `base.ComputationalSecurityBits` challenge bits.
+- The challenge is `base.ComputationalSecurityBytesCeil` bytes interpreted as `base.ComputationalSecurityBits` challenge bits. This intentionally fixes the repetition count to 128 bits rather than exposing `kappa` as a separate protocol parameter.
 - Signed integer samples use byte-aligned two's-complement sampling over exactly the requested byte length.
 - The repeated Paillier encryptions use `encryption.EncryptManyWithNonces`.
 - `ValidateStatement` checks that the witness opens `X`, `S`, and the Paillier relation, and that `x` and `y` satisfy the configured narrow ranges.

--- a/pkg/proofs/cggmp21/dec/dec.go
+++ b/pkg/proofs/cggmp21/dec/dec.go
@@ -1,0 +1,303 @@
+package dec
+
+import (
+	"encoding/binary"
+
+	"github.com/bronlabs/errs-go/errs"
+
+	"github.com/bronlabs/bron-crypto/pkg/base/algebra"
+	"github.com/bronlabs/bron-crypto/pkg/base/curves"
+	"github.com/bronlabs/bron-crypto/pkg/base/nt/num"
+	"github.com/bronlabs/bron-crypto/pkg/base/serde"
+	"github.com/bronlabs/bron-crypto/pkg/base/utils"
+	"github.com/bronlabs/bron-crypto/pkg/base/utils/sliceutils"
+	"github.com/bronlabs/bron-crypto/pkg/encryption/paillier"
+	"github.com/bronlabs/bron-crypto/pkg/proofs/sigma"
+)
+
+const (
+	// Name identifies the CGGMP21 Paillier special decryption in the exponent proof.
+	Name sigma.Name = "CGGMP21_PAILLIER_SPECIAL_DECRYPTION_IN_EXPONENT"
+)
+
+// Statement is the public input (N0, K, X, D, S) for CGGMP21 Figure 28.
+type Statement[G curves.Point[G, B, S], B algebra.PrimeFieldElement[B], S algebra.PrimeFieldElement[S]] struct {
+	n0 *paillier.PublicKey
+	k  *paillier.Ciphertext
+	x  G
+	d  *paillier.Ciphertext
+	s  G
+}
+
+type statementDTO[G curves.Point[G, B, S], B algebra.PrimeFieldElement[B], S algebra.PrimeFieldElement[S]] struct {
+	N0 *paillier.PublicKey  `cbor:"n0"`
+	K  *paillier.Ciphertext `cbor:"k"`
+	X  G                    `cbor:"x"`
+	D  *paillier.Ciphertext `cbor:"d"`
+	S  G                    `cbor:"s"`
+}
+
+// NewStatement constructs a Paillier special decryption-in-the-exponent statement.
+func NewStatement[G curves.Point[G, B, S], B algebra.PrimeFieldElement[B], S algebra.PrimeFieldElement[S]](
+	n0 *paillier.PublicKey,
+	k *paillier.Ciphertext,
+	x G,
+	d *paillier.Ciphertext,
+	s G,
+) (*Statement[G, B, S], error) {
+	if n0 == nil || k == nil || d == nil || utils.IsNil(x) || utils.IsNil(s) {
+		return nil, ErrInvalidArgument.WithMessage("statement values must not be nil")
+	}
+	return &Statement[G, B, S]{
+		n0: n0,
+		k:  k,
+		x:  x,
+		d:  d,
+		s:  s,
+	}, nil
+}
+
+// MarshalCBOR serialises the statement to CBOR format.
+func (s *Statement[G, B, S]) MarshalCBOR() ([]byte, error) {
+	dto := &statementDTO[G, B, S]{
+		N0: s.n0,
+		K:  s.k,
+		X:  s.x,
+		D:  s.d,
+		S:  s.s,
+	}
+	out, err := serde.MarshalCBOR(dto)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not marshal statement to CBOR")
+	}
+	return out, nil
+}
+
+// UnmarshalCBOR deserialises the statement from CBOR format.
+func (s *Statement[G, B, S]) UnmarshalCBOR(data []byte) error {
+	dto, err := serde.UnmarshalCBOR[*statementDTO[G, B, S]](data)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not unmarshal statement from CBOR")
+	}
+	if dto == nil {
+		return ErrInvalidArgument.WithMessage("statement DTO must not be nil")
+	}
+	statement, err := NewStatement(dto.N0, dto.K, dto.X, dto.D, dto.S)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("invalid statement data")
+	}
+	*s = *statement
+	return nil
+}
+
+// Bytes serialises the statement for transcript binding.
+func (s *Statement[G, B, S]) Bytes() []byte {
+	out := binary.LittleEndian.AppendUint64(nil, 5)
+	out = sliceutils.AppendLengthPrefixed(out, s.n0.Group().N().Bytes())
+	out = sliceutils.AppendLengthPrefixed(out, s.k.Bytes())
+	out = sliceutils.AppendLengthPrefixed(out, s.x.Bytes())
+	out = sliceutils.AppendLengthPrefixed(out, s.d.Bytes())
+	out = sliceutils.AppendLengthPrefixed(out, s.s.Bytes())
+	return out
+}
+
+// Witness is the secret input (x, y, rho) from CGGMP21 Figure 28.
+type Witness struct {
+	x   *num.Int
+	y   *num.Int
+	rho *paillier.Nonce
+}
+
+// NewWitness constructs a Paillier special decryption-in-the-exponent witness.
+func NewWitness(x, y *num.Int, rho *paillier.Nonce) (*Witness, error) {
+	if x == nil || y == nil || rho == nil {
+		return nil, ErrInvalidArgument.WithMessage("witness values must not be nil")
+	}
+	return &Witness{
+		x:   x.Clone(),
+		y:   y.Clone(),
+		rho: rho,
+	}, nil
+}
+
+// State stores the prover's per-repetition sampled randomness between sigma rounds.
+type State struct {
+	alpha []*num.Int
+	beta  []*num.Int
+	r     []*paillier.Nonce
+}
+
+// NewState constructs the prover state retained between sigma rounds.
+func NewState(alpha, beta []*num.Int, r []*paillier.Nonce) (*State, error) {
+	if err := validateIntSlice("state alpha", alpha); err != nil {
+		return nil, err
+	}
+	if err := validateIntSlice("state beta", beta); err != nil {
+		return nil, err
+	}
+	if err := validateNonceSlice("state r", r); err != nil {
+		return nil, err
+	}
+	return &State{
+		alpha: alpha,
+		beta:  beta,
+		r:     r,
+	}, nil
+}
+
+// Commitment is the prover's first message (A_j, B_j, C_j) for each repetition.
+type Commitment[G curves.Point[G, B, S], B algebra.PrimeFieldElement[B], S algebra.PrimeFieldElement[S]] struct {
+	a []*paillier.Ciphertext
+	b []G
+	c []G
+}
+
+type commitmentDTO[G curves.Point[G, B, S], B algebra.PrimeFieldElement[B], S algebra.PrimeFieldElement[S]] struct {
+	A []*paillier.Ciphertext `cbor:"a"`
+	B []G                    `cbor:"b"`
+	C []G                    `cbor:"c"`
+}
+
+// NewCommitment constructs a Paillier special decryption-in-the-exponent commitment.
+func NewCommitment[G curves.Point[G, B, S], B algebra.PrimeFieldElement[B], S algebra.PrimeFieldElement[S]](
+	a []*paillier.Ciphertext,
+	b []G,
+	c []G,
+) (*Commitment[G, B, S], error) {
+	if err := validateCiphertextSlice("commitment A", a); err != nil {
+		return nil, err
+	}
+	if len(b) != challengeBitsLength || len(c) != challengeBitsLength {
+		return nil, ErrInvalidArgument.WithMessage("commitment point slices must have length %d", challengeBitsLength)
+	}
+	for _, elem := range b {
+		if utils.IsNil(elem) {
+			return nil, ErrInvalidArgument.WithMessage("commitment B values must not be nil")
+		}
+	}
+	for _, elem := range c {
+		if utils.IsNil(elem) {
+			return nil, ErrInvalidArgument.WithMessage("commitment C values must not be nil")
+		}
+	}
+	return &Commitment[G, B, S]{
+		a: a,
+		b: b,
+		c: c,
+	}, nil
+}
+
+// MarshalCBOR serialises the commitment to CBOR format.
+func (c *Commitment[G, B, S]) MarshalCBOR() ([]byte, error) {
+	dto := &commitmentDTO[G, B, S]{
+		A: c.a,
+		B: c.b,
+		C: c.c,
+	}
+	out, err := serde.MarshalCBOR(dto)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not marshal commitment to CBOR")
+	}
+	return out, nil
+}
+
+// UnmarshalCBOR deserialises the commitment from CBOR format.
+func (c *Commitment[G, B, S]) UnmarshalCBOR(data []byte) error {
+	dto, err := serde.UnmarshalCBOR[*commitmentDTO[G, B, S]](data)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not unmarshal commitment from CBOR")
+	}
+	if dto == nil {
+		return ErrInvalidArgument.WithMessage("commitment DTO must not be nil")
+	}
+	commitment, err := NewCommitment(dto.A, dto.B, dto.C)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("invalid commitment data")
+	}
+	*c = *commitment
+	return nil
+}
+
+// Bytes serialises the commitment for transcript binding.
+func (c *Commitment[G, B, S]) Bytes() []byte {
+	out := binary.LittleEndian.AppendUint64(nil, uint64(len(c.a)))
+	for i := range c.a {
+		out = sliceutils.AppendLengthPrefixed(out, c.a[i].Bytes())
+		out = sliceutils.AppendLengthPrefixed(out, c.b[i].Bytes())
+		out = sliceutils.AppendLengthPrefixed(out, c.c[i].Bytes())
+	}
+	return out
+}
+
+// Response is the prover's final message (z_j, w_j, nu_j) for each repetition.
+type Response struct {
+	z  []*num.Int
+	w  []*num.Int
+	nu []*paillier.Nonce
+}
+
+type responseDTO struct {
+	Z  []*num.Int        `cbor:"z"`
+	W  []*num.Int        `cbor:"w"`
+	Nu []*paillier.Nonce `cbor:"nu"`
+}
+
+// NewResponse constructs a Paillier special decryption-in-the-exponent response.
+func NewResponse(z, w []*num.Int, nu []*paillier.Nonce) (*Response, error) {
+	if err := validateIntSlice("response z", z); err != nil {
+		return nil, err
+	}
+	if err := validateIntSlice("response w", w); err != nil {
+		return nil, err
+	}
+	if err := validateNonceSlice("response nu", nu); err != nil {
+		return nil, err
+	}
+	return &Response{
+		z:  z,
+		w:  w,
+		nu: nu,
+	}, nil
+}
+
+// MarshalCBOR serialises the response to CBOR format.
+func (r *Response) MarshalCBOR() ([]byte, error) {
+	dto := &responseDTO{
+		Z:  r.z,
+		W:  r.w,
+		Nu: r.nu,
+	}
+	out, err := serde.MarshalCBOR(dto)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not marshal response to CBOR")
+	}
+	return out, nil
+}
+
+// UnmarshalCBOR deserialises the response from CBOR format.
+func (r *Response) UnmarshalCBOR(data []byte) error {
+	dto, err := serde.UnmarshalCBOR[*responseDTO](data)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not unmarshal response from CBOR")
+	}
+	if dto == nil {
+		return ErrInvalidArgument.WithMessage("response DTO must not be nil")
+	}
+	response, err := NewResponse(dto.Z, dto.W, dto.Nu)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("invalid response data")
+	}
+	*r = *response
+	return nil
+}
+
+// Bytes serialises the response for transcript binding.
+func (r *Response) Bytes() []byte {
+	out := binary.LittleEndian.AppendUint64(nil, uint64(len(r.z)))
+	for i := range r.z {
+		out = sliceutils.AppendLengthPrefixed(out, r.z[i].Bytes())
+		out = sliceutils.AppendLengthPrefixed(out, r.w[i].Bytes())
+		out = sliceutils.AppendLengthPrefixed(out, r.nu[i].Bytes())
+	}
+	return out
+}

--- a/pkg/proofs/cggmp21/dec/dec_smoke_test.go
+++ b/pkg/proofs/cggmp21/dec/dec_smoke_test.go
@@ -1,0 +1,19 @@
+package dec_test
+
+import (
+	"github.com/bronlabs/bron-crypto/pkg/base/algebra"
+	"github.com/bronlabs/bron-crypto/pkg/base/curves"
+	"github.com/bronlabs/bron-crypto/pkg/proofs/cggmp21/dec"
+	"github.com/bronlabs/bron-crypto/pkg/proofs/sigma"
+	"github.com/bronlabs/bron-crypto/pkg/signatures/ecdsa"
+)
+
+func _[G curves.Point[G, B, S], B algebra.PrimeFieldElement[B], S algebra.PrimeFieldElement[S]](_ ecdsa.Curve[G, B, S]) {
+	var _ sigma.Statement = (*dec.Statement[G, B, S])(nil)
+	var _ sigma.Witness = (*dec.Witness)(nil)
+	var _ sigma.State = (*dec.State)(nil)
+	var _ sigma.Commitment = (*dec.Commitment[G, B, S])(nil)
+	var _ sigma.Response = (*dec.Response)(nil)
+
+	var _ sigma.Protocol[*dec.Statement[G, B, S], *dec.Witness, *dec.Commitment[G, B, S], *dec.State, *dec.Response] = (*dec.Protocol[G, B, S])(nil)
+}

--- a/pkg/proofs/cggmp21/dec/doc.go
+++ b/pkg/proofs/cggmp21/dec/doc.go
@@ -1,3 +1,7 @@
 // Package dec implements CGGMP21 Figure 28, the Paillier special decryption in
 // the exponent sigma protocol.
+//
+// CBOR unmarshalling validates local structure and nested type constructors.
+// Contextual checks that depend on protocol parameters or statement/witness
+// relations are performed by Protocol.ValidateStatement and Protocol.Verify.
 package dec

--- a/pkg/proofs/cggmp21/dec/doc.go
+++ b/pkg/proofs/cggmp21/dec/doc.go
@@ -1,0 +1,3 @@
+// Package dec implements CGGMP21 Figure 28, the Paillier special decryption in
+// the exponent sigma protocol.
+package dec

--- a/pkg/proofs/cggmp21/dec/errors.go
+++ b/pkg/proofs/cggmp21/dec/errors.go
@@ -1,0 +1,12 @@
+package dec
+
+import "github.com/bronlabs/errs-go/errs"
+
+var (
+	// ErrInvalidArgument indicates missing or inconsistent protocol inputs.
+	ErrInvalidArgument = errs.New("invalid argument")
+	// ErrValidationFailed indicates that a statement/witness pair is malformed or inconsistent.
+	ErrValidationFailed = errs.New("validation failed")
+	// ErrVerificationFailed indicates a failed sigma-protocol verification.
+	ErrVerificationFailed = errs.New("verification failed")
+)

--- a/pkg/proofs/cggmp21/dec/helpers.go
+++ b/pkg/proofs/cggmp21/dec/helpers.go
@@ -25,7 +25,7 @@ func intSampleRangeSymmetricBits(bitLen int, prngReader io.Reader) (*num.Int, er
 }
 
 func intInSignedBitRange(v *num.Int, bitLen int) bool {
-	return v.Abs().TrueLen() <= bitLen
+	return v.Abs().TrueLen() < bitLen
 }
 
 func intToPlaintext(v *num.Int, paillierKey *paillier.PublicKey) (*paillier.Plaintext, error) {

--- a/pkg/proofs/cggmp21/dec/helpers.go
+++ b/pkg/proofs/cggmp21/dec/helpers.go
@@ -1,0 +1,119 @@
+package dec
+
+import (
+	"io"
+	"math/big"
+
+	"github.com/bronlabs/errs-go/errs"
+
+	"github.com/bronlabs/bron-crypto/pkg/base/algebra"
+	"github.com/bronlabs/bron-crypto/pkg/base/nt/num"
+	"github.com/bronlabs/bron-crypto/pkg/encryption/paillier"
+)
+
+func intSampleRangeSymmetricBits(bitLen int, prngReader io.Reader) (*num.Int, error) {
+	buf := make([]byte, bitLen/8)
+	if _, err := io.ReadFull(prngReader, buf); err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not sample integer bytes")
+	}
+
+	out, err := num.Z().FromTwosComplementBytesBE(buf)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not parse sampled integer")
+	}
+	return out, nil
+}
+
+func intInSignedBitRange(v *num.Int, bitLen int) bool {
+	return v.Abs().TrueLen() <= bitLen
+}
+
+func intToPlaintext(v *num.Int, paillierKey *paillier.PublicKey) (*paillier.Plaintext, error) {
+	out, err := paillier.NewPlaintextSymmetric(v, paillierKey.PlaintextGroup().Modulus())
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not create signed Paillier plaintext")
+	}
+	return out, nil
+}
+
+func intsToPlaintexts(values []*num.Int, paillierKey *paillier.PublicKey) ([]*paillier.Plaintext, error) {
+	out := make([]*paillier.Plaintext, len(values))
+	for i, v := range values {
+		plaintext, err := intToPlaintext(v, paillierKey)
+		if err != nil {
+			return nil, errs.Wrap(err).WithMessage("could not create plaintext at index %d", i)
+		}
+		out[i] = plaintext
+	}
+	return out, nil
+}
+
+func intToScalar[S algebra.PrimeFieldElement[S]](v *num.Int, scalarField algebra.PrimeField[S]) (S, error) {
+	var nilS S
+	if v == nil {
+		return nilS, ErrInvalidArgument.WithMessage("integer must not be nil")
+	}
+	if scalarField == nil {
+		return nilS, ErrInvalidArgument.WithMessage("scalar field must not be nil")
+	}
+
+	modulus := scalarField.Order().Big()
+	reduced := new(big.Int).Mod(v.Big(), modulus)
+	if reduced.Sign() == 0 {
+		return scalarField.FromUint64(0), nil
+	}
+	out, err := scalarField.FromBytesBEReduce(reduced.Bytes())
+	if err != nil {
+		return nilS, errs.Wrap(err).WithMessage("could not reduce integer to scalar")
+	}
+	return out, nil
+}
+
+func signedBoundFitsPaillier(bits int, paillierKey *paillier.PublicKey) error {
+	if paillierKey == nil {
+		return ErrInvalidArgument.WithMessage("Paillier key must not be nil")
+	}
+	modulus := paillierKey.PlaintextGroup().Modulus()
+	bound := num.Z().One().Lsh(uint(bits))
+	halfModulus := modulus.Rsh(1).Lift()
+	if !bound.IsLessThanOrEqual(halfModulus) {
+		return ErrValidationFailed.WithMessage("2^%d must fit in the Paillier symmetric plaintext range", bits)
+	}
+	return nil
+}
+
+func validateIntSlice(name string, values []*num.Int) error {
+	if len(values) != challengeBitsLength {
+		return ErrInvalidArgument.WithMessage("%s must have length %d", name, challengeBitsLength)
+	}
+	for _, elem := range values {
+		if elem == nil {
+			return ErrInvalidArgument.WithMessage("%s values must not be nil", name)
+		}
+	}
+	return nil
+}
+
+func validateNonceSlice(name string, values []*paillier.Nonce) error {
+	if len(values) != challengeBitsLength {
+		return ErrInvalidArgument.WithMessage("%s must have length %d", name, challengeBitsLength)
+	}
+	for _, elem := range values {
+		if elem == nil {
+			return ErrInvalidArgument.WithMessage("%s values must not be nil", name)
+		}
+	}
+	return nil
+}
+
+func validateCiphertextSlice(name string, values []*paillier.Ciphertext) error {
+	if len(values) != challengeBitsLength {
+		return ErrInvalidArgument.WithMessage("%s must have length %d", name, challengeBitsLength)
+	}
+	for _, elem := range values {
+		if elem == nil {
+			return ErrInvalidArgument.WithMessage("%s values must not be nil", name)
+		}
+	}
+	return nil
+}

--- a/pkg/proofs/cggmp21/dec/protocol.go
+++ b/pkg/proofs/cggmp21/dec/protocol.go
@@ -1,0 +1,592 @@
+package dec
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/bronlabs/errs-go/errs"
+
+	"github.com/bronlabs/bron-crypto/pkg/base"
+	"github.com/bronlabs/bron-crypto/pkg/base/algebra"
+	"github.com/bronlabs/bron-crypto/pkg/base/curves"
+	"github.com/bronlabs/bron-crypto/pkg/base/nt/num"
+	"github.com/bronlabs/bron-crypto/pkg/base/utils"
+	"github.com/bronlabs/bron-crypto/pkg/encryption"
+	"github.com/bronlabs/bron-crypto/pkg/encryption/paillier"
+	"github.com/bronlabs/bron-crypto/pkg/proofs/sigma"
+	"github.com/bronlabs/bron-crypto/pkg/signatures/ecdsa"
+)
+
+const (
+	challengeBitsLength  = base.ComputationalSecurityBits
+	challengeBytesLength = base.ComputationalSecurityBytesCeil
+)
+
+// Protocol implements the CGGMP21 Paillier special decryption in the exponent proof from Figure 28.
+type Protocol[G curves.Point[G, B, S], B algebra.PrimeFieldElement[B], S algebra.PrimeFieldElement[S]] struct {
+	name    sigma.Name
+	l       int
+	lPrime  int
+	epsilon int
+	curve   ecdsa.Curve[G, B, S]
+	prng    io.Reader
+}
+
+// NewProtocol constructs the CGGMP21 Figure 28 Paillier special decryption sigma protocol.
+func NewProtocol[G curves.Point[G, B, S], B algebra.PrimeFieldElement[B], S algebra.PrimeFieldElement[S]](l, lPrime, epsilon int, curve ecdsa.Curve[G, B, S], prng io.Reader) (*Protocol[G, B, S], error) {
+	if prng == nil {
+		return nil, ErrInvalidArgument.WithMessage("prng is required")
+	}
+	if utils.IsNil(curve) {
+		return nil, ErrInvalidArgument.WithMessage("curve is required")
+	}
+	if (l <= 0) || (l%8 != 0) {
+		return nil, ErrInvalidArgument.WithMessage("l must be a multiple of 8")
+	}
+	if (lPrime <= 0) || (lPrime%8 != 0) {
+		return nil, ErrInvalidArgument.WithMessage("lPrime must be a multiple of 8")
+	}
+	if (epsilon <= 0) || (epsilon%8 != 0) {
+		return nil, ErrInvalidArgument.WithMessage("epsilon must be a multiple of 8")
+	}
+
+	k := curve.ScalarField().BitLen()
+	if k < base.ComputationalSecurityBits {
+		return nil, ErrInvalidArgument.WithMessage("invalid curve")
+	}
+	if l < k {
+		return nil, ErrInvalidArgument.WithMessage("invalid l")
+	}
+	if epsilon < l+k {
+		return nil, ErrInvalidArgument.WithMessage("invalid epsilon")
+	}
+	if lPrime < l+epsilon+2*l {
+		return nil, ErrInvalidArgument.WithMessage("invalid lPrime")
+	}
+
+	name := sigma.Name(fmt.Sprintf(
+		"%s_L=%d_LPRIME=%d_EPS=%d_CURVE=%s_KAPPA=%d",
+		Name,
+		l,
+		lPrime,
+		epsilon,
+		curve.Name(),
+		challengeBitsLength,
+	))
+	p := &Protocol[G, B, S]{
+		name:    name,
+		l:       l,
+		lPrime:  lPrime,
+		epsilon: epsilon,
+		curve:   curve,
+		prng:    prng,
+	}
+	return p, nil
+}
+
+// Name returns the protocol identifier, including public parameters.
+func (p *Protocol[G, B, S]) Name() sigma.Name {
+	return p.name
+}
+
+// ComputeProverCommitment generates the prover's first message.
+func (p *Protocol[G, B, S]) ComputeProverCommitment(statement *Statement[G, B, S], witness *Witness) (*Commitment[G, B, S], *State, error) {
+	if statement == nil {
+		return nil, nil, ErrInvalidArgument.WithMessage("statement must not be nil")
+	}
+	if witness == nil {
+		return nil, nil, ErrInvalidArgument.WithMessage("witness must not be nil")
+	}
+	if err := p.validateStatement(statement); err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("invalid statement")
+	}
+
+	state, err := p.sampleState(statement)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not sample prover state")
+	}
+	commitment, err := p.computeCommitment(statement, state)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not compute prover commitment")
+	}
+	return commitment, state, nil
+}
+
+// ComputeProverResponse generates the prover response for a fixed challenge.
+func (p *Protocol[G, B, S]) ComputeProverResponse(statement *Statement[G, B, S], witness *Witness, commitment *Commitment[G, B, S], state *State, challenge sigma.ChallengeBytes) (*Response, error) {
+	if statement == nil {
+		return nil, ErrInvalidArgument.WithMessage("statement must not be nil")
+	}
+	if witness == nil {
+		return nil, ErrInvalidArgument.WithMessage("witness must not be nil")
+	}
+	if commitment == nil {
+		return nil, ErrInvalidArgument.WithMessage("commitment must not be nil")
+	}
+	if state == nil {
+		return nil, ErrInvalidArgument.WithMessage("state must not be nil")
+	}
+	if err := p.validateStatement(statement); err != nil {
+		return nil, errs.Wrap(err).WithMessage("invalid statement")
+	}
+	bits, err := p.mapChallenge(challenge)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("invalid challenge")
+	}
+
+	z := make([]*num.Int, challengeBitsLength)
+	w := make([]*num.Int, challengeBitsLength)
+	nu := make([]*paillier.Nonce, challengeBitsLength)
+	for i, bit := range bits {
+		e := bitToInt(bit)
+		z[i] = state.alpha[i].Add(e.Mul(witness.x))
+		w[i] = state.beta[i].Add(e.Mul(witness.y))
+		nu[i] = state.r[i]
+		if bit == 1 {
+			nu[i], err = statement.n0.NonceOp(state.r[i], witness.rho)
+			if err != nil {
+				return nil, errs.Wrap(err).WithMessage("could not compute nu at index %d", i)
+			}
+		}
+	}
+
+	response, err := NewResponse(z, w, nu)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not create response")
+	}
+	return response, nil
+}
+
+// Verify checks the Figure 28 equality checks and widened response ranges.
+func (p *Protocol[G, B, S]) Verify(statement *Statement[G, B, S], commitment *Commitment[G, B, S], challenge sigma.ChallengeBytes, response *Response) error {
+	if statement == nil {
+		return ErrInvalidArgument.WithMessage("statement must not be nil")
+	}
+	if commitment == nil {
+		return ErrInvalidArgument.WithMessage("commitment must not be nil")
+	}
+	if response == nil {
+		return ErrInvalidArgument.WithMessage("response must not be nil")
+	}
+	if err := p.validateStatement(statement); err != nil {
+		return errs.Wrap(err).WithMessage("invalid statement")
+	}
+	if err := p.validateCommitment(statement, commitment); err != nil {
+		return errs.Wrap(err).WithMessage("invalid commitment")
+	}
+	if err := p.validateResponse(statement, response); err != nil {
+		return errs.Wrap(err).WithMessage("invalid response")
+	}
+	bits, err := p.mapChallenge(challenge)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("invalid challenge")
+	}
+
+	for i := range bits {
+		if !intInSignedBitRange(response.z[i], p.l+p.epsilon) {
+			return ErrVerificationFailed.WithMessage("z is out of range at index %d", i)
+		}
+		if !intInSignedBitRange(response.w[i], p.lPrime+p.epsilon) {
+			return ErrVerificationFailed.WithMessage("w is out of range at index %d", i)
+		}
+	}
+
+	wPlaintexts, err := intsToPlaintexts(response.w, statement.n0)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not create w plaintexts")
+	}
+	encW, err := encryption.EncryptManyWithNonces(wPlaintexts, statement.n0, response.nu)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not encrypt w values under N0")
+	}
+
+	for i, bit := range bits {
+		if err := p.verifyPaillier(statement, commitment, response, encW[i], bit, i); err != nil {
+			return errs.Wrap(err).WithMessage("Paillier equality failed at index %d", i)
+		}
+		if err := p.verifyCurve(statement, commitment, response, bit, i); err != nil {
+			return errs.Wrap(err).WithMessage("curve equality failed at index %d", i)
+		}
+	}
+	return nil
+}
+
+// RunSimulator creates an honest-verifier simulated transcript for a fixed challenge.
+func (p *Protocol[G, B, S]) RunSimulator(statement *Statement[G, B, S], challenge sigma.ChallengeBytes) (*Commitment[G, B, S], *Response, error) {
+	if statement == nil {
+		return nil, nil, ErrInvalidArgument.WithMessage("statement must not be nil")
+	}
+	if err := p.validateStatement(statement); err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("invalid statement")
+	}
+	bits, err := p.mapChallenge(challenge)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("invalid challenge")
+	}
+
+	z := make([]*num.Int, challengeBitsLength)
+	w := make([]*num.Int, challengeBitsLength)
+	nu := make([]*paillier.Nonce, challengeBitsLength)
+	for i := range challengeBitsLength {
+		z[i], err = intSampleRangeSymmetricBits(p.l+p.epsilon, p.prng)
+		if err != nil {
+			return nil, nil, errs.Wrap(err).WithMessage("could not sample z at index %d", i)
+		}
+		w[i], err = intSampleRangeSymmetricBits(p.lPrime+p.epsilon, p.prng)
+		if err != nil {
+			return nil, nil, errs.Wrap(err).WithMessage("could not sample w at index %d", i)
+		}
+		nu[i], err = statement.n0.SampleNonce(p.prng)
+		if err != nil {
+			return nil, nil, errs.Wrap(err).WithMessage("could not sample nu at index %d", i)
+		}
+	}
+	response, err := NewResponse(z, w, nu)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not create response")
+	}
+
+	a, err := p.simulateA(statement, response, bits)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not compute simulated A")
+	}
+	b, err := p.simulateB(statement, response, bits)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not compute simulated B")
+	}
+	c, err := p.simulateC(statement, response, bits)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not compute simulated C")
+	}
+	commitment, err := NewCommitment(a, b, c)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not create commitment")
+	}
+	return commitment, response, nil
+}
+
+// SpecialSoundness returns the protocol extraction parameter.
+func (*Protocol[G, B, S]) SpecialSoundness() uint {
+	return 2
+}
+
+// SoundnessError returns the kappa-bit soundness error.
+func (*Protocol[G, B, S]) SoundnessError() uint {
+	return uint(challengeBitsLength)
+}
+
+// GetChallengeBytesLength returns the challenge size in bytes.
+func (*Protocol[G, B, S]) GetChallengeBytesLength() int {
+	return challengeBytesLength
+}
+
+// ValidateStatement checks that the witness opens the public statement and lies in the configured ranges.
+func (p *Protocol[G, B, S]) ValidateStatement(statement *Statement[G, B, S], witness *Witness) error {
+	if statement == nil {
+		return ErrInvalidArgument.WithMessage("statement must not be nil")
+	}
+	if witness == nil {
+		return ErrInvalidArgument.WithMessage("witness must not be nil")
+	}
+	if err := p.validateStatement(statement); err != nil {
+		return errs.Wrap(err).WithMessage("invalid statement")
+	}
+	if err := p.validateWitness(statement, witness); err != nil {
+		return errs.Wrap(err).WithMessage("invalid witness")
+	}
+	return nil
+}
+
+func (p *Protocol[G, B, S]) sampleState(statement *Statement[G, B, S]) (*State, error) {
+	alpha := make([]*num.Int, challengeBitsLength)
+	beta := make([]*num.Int, challengeBitsLength)
+	r := make([]*paillier.Nonce, challengeBitsLength)
+	for i := range challengeBitsLength {
+		var err error
+		alpha[i], err = intSampleRangeSymmetricBits(p.l+p.epsilon, p.prng)
+		if err != nil {
+			return nil, errs.Wrap(err).WithMessage("could not sample alpha at index %d", i)
+		}
+		beta[i], err = intSampleRangeSymmetricBits(p.lPrime+p.epsilon, p.prng)
+		if err != nil {
+			return nil, errs.Wrap(err).WithMessage("could not sample beta at index %d", i)
+		}
+		r[i], err = statement.n0.SampleNonce(p.prng)
+		if err != nil {
+			return nil, errs.Wrap(err).WithMessage("could not sample r at index %d", i)
+		}
+	}
+
+	state, err := NewState(alpha, beta, r)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not create state")
+	}
+	return state, nil
+}
+
+func (p *Protocol[G, B, S]) computeCommitment(statement *Statement[G, B, S], state *State) (*Commitment[G, B, S], error) {
+	betaPlaintexts, err := intsToPlaintexts(state.beta, statement.n0)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not create beta plaintexts")
+	}
+	encBeta, err := encryption.EncryptManyWithNonces(betaPlaintexts, statement.n0, state.r)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not encrypt beta values")
+	}
+
+	a := make([]*paillier.Ciphertext, challengeBitsLength)
+	b := make([]G, challengeBitsLength)
+	c := make([]G, challengeBitsLength)
+	for i := range challengeBitsLength {
+		kNegAlpha, err := statement.n0.CiphertextScalarOp(statement.k, state.alpha[i].Neg())
+		if err != nil {
+			return nil, errs.Wrap(err).WithMessage("could not compute K^-alpha at index %d", i)
+		}
+		a[i], err = statement.n0.CiphertextOp(kNegAlpha, encBeta[i])
+		if err != nil {
+			return nil, errs.Wrap(err).WithMessage("could not compute A at index %d", i)
+		}
+		betaScalar, err := intToScalar(state.beta[i], p.curve.ScalarField())
+		if err != nil {
+			return nil, errs.Wrap(err).WithMessage("could not convert beta to scalar at index %d", i)
+		}
+		b[i] = p.curve.ScalarBaseMul(betaScalar)
+		alphaScalar, err := intToScalar(state.alpha[i], p.curve.ScalarField())
+		if err != nil {
+			return nil, errs.Wrap(err).WithMessage("could not convert alpha to scalar at index %d", i)
+		}
+		c[i] = p.curve.ScalarBaseMul(alphaScalar)
+	}
+
+	commitment, err := NewCommitment(a, b, c)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not create commitment")
+	}
+	return commitment, nil
+}
+
+func (*Protocol[G, B, S]) verifyPaillier(statement *Statement[G, B, S], commitment *Commitment[G, B, S], response *Response, encW *paillier.Ciphertext, bit byte, index int) error {
+	kNegZ, err := statement.n0.CiphertextScalarOp(statement.k, response.z[index].Neg())
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not compute K^-z")
+	}
+	left, err := statement.n0.CiphertextOp(encW, kNegZ)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not compute Paillier left side")
+	}
+	right := commitment.a[index]
+	if bit == 1 {
+		right, err = statement.n0.CiphertextOp(right, statement.d)
+		if err != nil {
+			return errs.Wrap(err).WithMessage("could not compute Paillier right side")
+		}
+	}
+	if !left.Equal(right) {
+		return ErrVerificationFailed.WithMessage("Paillier equality check failed")
+	}
+	return nil
+}
+
+func (p *Protocol[G, B, S]) verifyCurve(statement *Statement[G, B, S], commitment *Commitment[G, B, S], response *Response, bit byte, index int) error {
+	zScalar, err := intToScalar(response.z[index], p.curve.ScalarField())
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not convert z to scalar")
+	}
+	wScalar, err := intToScalar(response.w[index], p.curve.ScalarField())
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not convert w to scalar")
+	}
+
+	leftX := p.curve.ScalarBaseMul(zScalar)
+	rightX := commitment.c[index]
+	if bit == 1 {
+		rightX = rightX.Op(statement.x)
+	}
+	if !leftX.Equal(rightX) {
+		return ErrVerificationFailed.WithMessage("X equality check failed")
+	}
+
+	leftS := p.curve.ScalarBaseMul(wScalar)
+	rightS := commitment.b[index]
+	if bit == 1 {
+		rightS = rightS.Op(statement.s)
+	}
+	if !leftS.Equal(rightS) {
+		return ErrVerificationFailed.WithMessage("S equality check failed")
+	}
+	return nil
+}
+
+func (*Protocol[G, B, S]) simulateA(statement *Statement[G, B, S], response *Response, bits []byte) ([]*paillier.Ciphertext, error) {
+	wPlaintexts, err := intsToPlaintexts(response.w, statement.n0)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not create w plaintexts")
+	}
+	encW, err := encryption.EncryptManyWithNonces(wPlaintexts, statement.n0, response.nu)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not encrypt w values")
+	}
+
+	dInv, err := statement.n0.CiphertextOpInv(statement.d)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not invert D")
+	}
+	out := make([]*paillier.Ciphertext, challengeBitsLength)
+	for i, bit := range bits {
+		kNegZ, err := statement.n0.CiphertextScalarOp(statement.k, response.z[i].Neg())
+		if err != nil {
+			return nil, errs.Wrap(err).WithMessage("could not compute K^-z at index %d", i)
+		}
+		out[i], err = statement.n0.CiphertextOp(encW[i], kNegZ)
+		if err != nil {
+			return nil, errs.Wrap(err).WithMessage("could not compute response side at index %d", i)
+		}
+		if bit == 1 {
+			out[i], err = statement.n0.CiphertextOp(out[i], dInv)
+			if err != nil {
+				return nil, errs.Wrap(err).WithMessage("could not compute A at index %d", i)
+			}
+		}
+	}
+	return out, nil
+}
+
+func (p *Protocol[G, B, S]) simulateB(statement *Statement[G, B, S], response *Response, bits []byte) ([]G, error) {
+	out := make([]G, challengeBitsLength)
+	sInv := statement.s.OpInv()
+	for i, bit := range bits {
+		wScalar, err := intToScalar(response.w[i], p.curve.ScalarField())
+		if err != nil {
+			return nil, errs.Wrap(err).WithMessage("could not convert w to scalar at index %d", i)
+		}
+		out[i] = p.curve.ScalarBaseMul(wScalar)
+		if bit == 1 {
+			out[i] = out[i].Op(sInv)
+		}
+	}
+	return out, nil
+}
+
+func (p *Protocol[G, B, S]) simulateC(statement *Statement[G, B, S], response *Response, bits []byte) ([]G, error) {
+	out := make([]G, challengeBitsLength)
+	xInv := statement.x.OpInv()
+	for i, bit := range bits {
+		zScalar, err := intToScalar(response.z[i], p.curve.ScalarField())
+		if err != nil {
+			return nil, errs.Wrap(err).WithMessage("could not convert z to scalar at index %d", i)
+		}
+		out[i] = p.curve.ScalarBaseMul(zScalar)
+		if bit == 1 {
+			out[i] = out[i].Op(xInv)
+		}
+	}
+	return out, nil
+}
+
+func (*Protocol[G, B, S]) mapChallenge(challenge sigma.ChallengeBytes) ([]byte, error) {
+	if len(challenge) != challengeBytesLength {
+		return nil, ErrInvalidArgument.WithMessage("invalid challenge length")
+	}
+	out := make([]byte, challengeBitsLength)
+	for i := range challengeBitsLength {
+		out[i] = (challenge[i/8] >> uint(7-(i%8))) & 1
+	}
+	return out, nil
+}
+
+func (p *Protocol[G, B, S]) validateStatement(statement *Statement[G, B, S]) error {
+	if statement.n0.PlaintextGroup().Modulus().TrueLen()%8 != 0 {
+		return ErrValidationFailed.WithMessage("Paillier modulus bit length must be byte-aligned")
+	}
+	if err := signedBoundFitsPaillier(p.lPrime+p.epsilon, statement.n0); err != nil {
+		return errs.Wrap(err).WithMessage("invalid N0 modulus for w response range")
+	}
+	if !statement.n0.CiphertextGroup().Contains(statement.k.Value()) ||
+		!statement.n0.CiphertextGroup().Contains(statement.d.Value()) {
+
+		return ErrValidationFailed.WithMessage("K and D must be in the N0 ciphertext group")
+	}
+	if !p.curve.Contains(statement.x) || !p.curve.Contains(statement.s) {
+		return ErrValidationFailed.WithMessage("X and S must be in the curve group")
+	}
+	return nil
+}
+
+func (p *Protocol[G, B, S]) validateWitness(statement *Statement[G, B, S], witness *Witness) error {
+	if !intInSignedBitRange(witness.x, p.l) {
+		return ErrValidationFailed.WithMessage("x is out of range")
+	}
+	if !intInSignedBitRange(witness.y, p.lPrime) {
+		return ErrValidationFailed.WithMessage("y is out of range")
+	}
+	if !statement.n0.NonceGroup().Contains(witness.rho.Value()) {
+		return ErrValidationFailed.WithMessage("rho is not in the N0 nonce group")
+	}
+
+	xScalar, err := intToScalar(witness.x, p.curve.ScalarField())
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not convert x to scalar")
+	}
+	if !p.curve.ScalarBaseMul(xScalar).Equal(statement.x) {
+		return ErrValidationFailed.WithMessage("x does not open X")
+	}
+	yScalar, err := intToScalar(witness.y, p.curve.ScalarField())
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not convert y to scalar")
+	}
+	if !p.curve.ScalarBaseMul(yScalar).Equal(statement.s) {
+		return ErrValidationFailed.WithMessage("y does not open S")
+	}
+
+	yPlaintext, err := intToPlaintext(witness.y, statement.n0)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not create y plaintext")
+	}
+	encY, err := statement.n0.EncryptWithNonce(yPlaintext, witness.rho)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not encrypt y")
+	}
+	kX, err := statement.n0.CiphertextScalarOp(statement.k, witness.x)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not compute K^x")
+	}
+	right, err := statement.n0.CiphertextOp(kX, statement.d)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not compute K^x D")
+	}
+	if !encY.Equal(right) {
+		return ErrValidationFailed.WithMessage("witness does not open Paillier relation")
+	}
+	return nil
+}
+
+func (p *Protocol[G, B, S]) validateCommitment(statement *Statement[G, B, S], commitment *Commitment[G, B, S]) error {
+	for i := range challengeBitsLength {
+		if !statement.n0.CiphertextGroup().Contains(commitment.a[i].Value()) {
+			return ErrValidationFailed.WithMessage("A must be in the N0 ciphertext group at index %d", i)
+		}
+		if !p.curve.Contains(commitment.b[i]) {
+			return ErrValidationFailed.WithMessage("B must be in the curve group at index %d", i)
+		}
+		if !p.curve.Contains(commitment.c[i]) {
+			return ErrValidationFailed.WithMessage("C must be in the curve group at index %d", i)
+		}
+	}
+	return nil
+}
+
+func (*Protocol[G, B, S]) validateResponse(statement *Statement[G, B, S], response *Response) error {
+	for i := range challengeBitsLength {
+		if !statement.n0.NonceGroup().Contains(response.nu[i].Value()) {
+			return ErrValidationFailed.WithMessage("nu must be in the N0 nonce group at index %d", i)
+		}
+	}
+	return nil
+}
+
+func bitToInt(bit byte) *num.Int {
+	if bit == 0 {
+		return num.Z().Zero()
+	}
+	return num.Z().One()
+}

--- a/pkg/proofs/cggmp21/dec/protocol_test.go
+++ b/pkg/proofs/cggmp21/dec/protocol_test.go
@@ -1,0 +1,105 @@
+package dec_test
+
+import (
+	"io"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bronlabs/bron-crypto/pkg/base/curves/k256"
+	"github.com/bronlabs/bron-crypto/pkg/base/nt/num"
+	"github.com/bronlabs/bron-crypto/pkg/base/prng/pcg"
+	"github.com/bronlabs/bron-crypto/pkg/encryption/paillier"
+	ntu "github.com/bronlabs/bron-crypto/pkg/network/testutils"
+	"github.com/bronlabs/bron-crypto/pkg/proofs/cggmp21/dec"
+)
+
+const (
+	testL       = 256
+	testLPrime  = 1280
+	testEpsilon = 512
+	testKeyBits = 2048
+)
+
+func TestProtocolHappyPathAndSimulator(t *testing.T) {
+	t.Parallel()
+
+	prng := pcg.NewRandomised()
+	protocol, statement, witness := sampleProtocolStatementAndWitness(t, prng)
+	challenge := make([]byte, protocol.GetChallengeBytesLength())
+	_, err := io.ReadFull(prng, challenge)
+	require.NoError(t, err)
+
+	require.NoError(t, protocol.ValidateStatement(statement, witness))
+
+	commitment, state, err := protocol.ComputeProverCommitment(statement, witness)
+	require.NoError(t, err)
+	response, err := protocol.ComputeProverResponse(statement, witness, commitment, state, challenge)
+	require.NoError(t, err)
+	require.NoError(t, protocol.Verify(statement, commitment, challenge, response))
+
+	roundTrippedStatement := ntu.CBORRoundTrip(t, statement)
+	require.Equal(t, statement.Bytes(), roundTrippedStatement.Bytes())
+	roundTrippedCommitment := ntu.CBORRoundTrip(t, commitment)
+	require.Equal(t, commitment.Bytes(), roundTrippedCommitment.Bytes())
+	roundTrippedResponse := ntu.CBORRoundTrip(t, response)
+	require.Equal(t, response.Bytes(), roundTrippedResponse.Bytes())
+	require.NoError(t, protocol.Verify(roundTrippedStatement, roundTrippedCommitment, challenge, roundTrippedResponse))
+
+	simulatedCommitment, simulatedResponse, err := protocol.RunSimulator(statement, challenge)
+	require.NoError(t, err)
+	require.NoError(t, protocol.Verify(statement, simulatedCommitment, challenge, simulatedResponse))
+}
+
+func sampleProtocolStatementAndWitness(
+	t *testing.T,
+	prng io.Reader,
+) (*dec.Protocol[*k256.Point, *k256.BaseFieldElement, *k256.Scalar], *dec.Statement[*k256.Point, *k256.BaseFieldElement, *k256.Scalar], *dec.Witness) {
+	t.Helper()
+
+	secretKey, err := paillier.SampleSecretKey(testKeyBits, prng)
+	require.NoError(t, err)
+	n0 := secretKey.Public()
+
+	curve := k256.NewCurve()
+	protocol, err := dec.NewProtocol(testL, testLPrime, testEpsilon, curve, prng)
+	require.NoError(t, err)
+
+	xInt := num.Z().FromInt64(42)
+	xScalar, err := curve.ScalarField().FromBytesBEReduce(xInt.Big().Bytes())
+	require.NoError(t, err)
+	xPoint := curve.ScalarBaseMul(xScalar)
+
+	yInt := num.Z().FromInt64(-17)
+	yReduced := new(big.Int).Mod(yInt.Big(), curve.ScalarField().Order().Big())
+	yScalar, err := curve.ScalarField().FromBytesBEReduce(yReduced.Bytes())
+	require.NoError(t, err)
+	sPoint := curve.ScalarBaseMul(yScalar)
+
+	kPlaintext, err := paillier.NewPlaintextSymmetric(num.Z().FromInt64(123), n0.PlaintextGroup().Modulus())
+	require.NoError(t, err)
+	kNonce, err := n0.SampleNonce(prng)
+	require.NoError(t, err)
+	k, err := n0.EncryptWithNonce(kPlaintext, kNonce)
+	require.NoError(t, err)
+
+	rho, err := n0.SampleNonce(prng)
+	require.NoError(t, err)
+	yPlaintext, err := paillier.NewPlaintextSymmetric(yInt, n0.PlaintextGroup().Modulus())
+	require.NoError(t, err)
+	encY, err := n0.EncryptWithNonce(yPlaintext, rho)
+	require.NoError(t, err)
+	kX, err := n0.CiphertextScalarOp(k, xInt)
+	require.NoError(t, err)
+	kXInv, err := n0.CiphertextOpInv(kX)
+	require.NoError(t, err)
+	d, err := n0.CiphertextOp(encY, kXInv)
+	require.NoError(t, err)
+
+	statement, err := dec.NewStatement(n0, k, xPoint, d, sPoint)
+	require.NoError(t, err)
+	witness, err := dec.NewWitness(xInt, yInt, rho)
+	require.NoError(t, err)
+	return protocol, statement, witness
+}

--- a/pkg/proofs/cggmp21/enc/README.md
+++ b/pkg/proofs/cggmp21/enc/README.md
@@ -79,8 +79,8 @@ $$
 
 `NewProtocol` checks that the Paillier modulus bit length, the Ring-Pedersen
 modulus bit length, `rangeBits`, and `slackBits` are all multiples of 8. The
-samplers use byte-aligned two's-complement encodings and then prepend a random
-sign-extension byte, producing values in $[-2^b, 2^b)$.
+samplers read exactly `b/8` random bytes and decode them as two's-complement
+big-endian, producing values in $[-2^{b-1}, 2^{b-1})$.
 
 The implementation uses a 128-bit two's-complement challenge, exposed by
 `challengeBitsLength`, rather than the curve-order challenge domain used in
@@ -88,9 +88,9 @@ CGGMP21 Figure 11. `SoundnessError` therefore reports 128 bits. The constructor
 requires `slackBits` to cover both this challenge length and the configured
 witness range with an additional computational-security margin.
 
-`inSignedBitRange` intentionally rejects the lower endpoint $-2^b$ by checking
-`abs(x).TrueLen() <= b`. This is a conservative choice: the sampler reaches
-that endpoint with probability $2^{-(b+1)}$, which is negligible for the
+`inSignedBitRange` intentionally rejects the lower endpoint $-2^{b-1}$ by
+checking `abs(x).TrueLen() < b`. This is a conservative choice: the sampler
+reaches that endpoint with probability $2^{-b}$, which is negligible for the
 parameter sizes accepted by the constructor.
 
 The Paillier modulus check requires the widened response bound $2^{l+\epsilon}$

--- a/pkg/proofs/cggmp21/enc/doc.go
+++ b/pkg/proofs/cggmp21/enc/doc.go
@@ -1,3 +1,7 @@
 // Package enc implements CGGMP21 Figure 11, the Paillier Encryption in Range
 // sigma protocol Πenc.
+//
+// CBOR unmarshalling validates local structure and nested type constructors.
+// Contextual checks that depend on protocol parameters or statement/witness
+// relations are performed by Protocol.ValidateStatement and Protocol.Verify.
 package enc

--- a/pkg/proofs/cggmp21/enc/helpers.go
+++ b/pkg/proofs/cggmp21/enc/helpers.go
@@ -21,11 +21,11 @@ func intRandomBitsSymmetric(bits int, prng io.Reader) (*num.Int, error) {
 	if bits%8 != 0 {
 		return nil, ErrInvalidArgument.WithMessage("bits must be a multiple of 8")
 	}
-	outBytes := make([]byte, bits/8+1)
+	outBytes := make([]byte, bits/8)
 	if _, err := io.ReadFull(prng, outBytes); err != nil {
 		return nil, errs.Wrap(err).WithMessage("could not read random bytes")
 	}
-	outBytes[0] = byte(int8(outBytes[0]) >> 7)
+
 	out, err := num.Z().FromTwosComplementBytesBE(outBytes)
 	if err != nil {
 		return nil, errs.Wrap(err).WithMessage("could not parse signed integer")
@@ -34,9 +34,9 @@ func intRandomBitsSymmetric(bits int, prng io.Reader) (*num.Int, error) {
 }
 
 func inSignedBitRange(v *num.Int, bits int) bool {
-	// Conservatively reject -2^bits even though intRandomBitsSymmetric can
-	// sample it with probability 2^-(bits+1), which is negligible here.
-	return v.Abs().TrueLen() <= bits
+	// Conservatively reject -2^(bits-1), the lower endpoint sampled by
+	// intRandomBitsSymmetric with probability 2^-bits.
+	return v.Abs().TrueLen() < bits
 }
 
 func signedBoundFitsPaillier[EK paillier.EncryptionKey[EK]](bits int, paillierKey EK) error {

--- a/pkg/proofs/cggmp21/enc/protocol_internal_test.go
+++ b/pkg/proofs/cggmp21/enc/protocol_internal_test.go
@@ -123,10 +123,9 @@ func sampleInternalTestInputs(
 }
 
 func randomInternalSignedBits(bits int, prng io.Reader) (*num.Int, error) {
-	outBytes := make([]byte, bits/8+1)
+	outBytes := make([]byte, bits/8)
 	if _, err := io.ReadFull(prng, outBytes); err != nil {
 		return nil, err
 	}
-	outBytes[0] = byte(int8(outBytes[0]) >> 7)
 	return num.Z().FromTwosComplementBytesBE(outBytes)
 }

--- a/pkg/proofs/cggmp21/enc/protocol_test.go
+++ b/pkg/proofs/cggmp21/enc/protocol_test.go
@@ -186,10 +186,9 @@ func TestSimulator(t *testing.T) {
 }
 
 func randomSignedBits(bits int, prng io.Reader) (*num.Int, error) {
-	outBytes := make([]byte, bits/8+1)
+	outBytes := make([]byte, bits/8)
 	if _, err := io.ReadFull(prng, outBytes); err != nil {
 		return nil, err
 	}
-	outBytes[0] = byte(int8(outBytes[0]) >> 7)
 	return num.Z().FromTwosComplementBytesBE(outBytes)
 }

--- a/pkg/proofs/cggmp21/encelg/README.md
+++ b/pkg/proofs/cggmp21/encelg/README.md
@@ -80,7 +80,7 @@ $$
 - `Statement` stores `N0`, `C`, `A` as an ElGamal public key, and `(B, X)` as an ElGamal ciphertext named `bx`.
 - `Witness` stores `x` as `*num.Int`, `rho` as a Paillier nonce, `a` as an ElGamal secret key, and the `(B, X)` nonce as `bx`.
 - `Commitment` stores `(Z, Y)` as an ElGamal ciphertext named `yz` under `A`.
-- The challenge is interpreted as a signed integer from exactly `base.ComputationalSecurityBytesCeil` bytes.
+- The challenge is interpreted as a signed integer from exactly `base.ComputationalSecurityBytesCeil` bytes. This intentionally fixes the Fiat-Shamir challenge domain to 128 bits rather than the paper's curve-order-sized challenge.
 - Signed integer samples use byte-aligned two's-complement sampling over exactly the requested byte length.
 - `ValidateStatement` checks that the witness opens `C`, `A`, and the ElGamal ciphertext `(B, X)`, and that `x` satisfies the configured narrow range.
 - Statement validation checks that the Paillier modulus can encode the widened `z1` range `l + epsilon` in its symmetric plaintext interval.

--- a/pkg/proofs/cggmp21/encelg/README.md
+++ b/pkg/proofs/cggmp21/encelg/README.md
@@ -1,0 +1,93 @@
+# CGGMP21 Range Proof with ElGamal Commitment
+
+This package implements the sigma protocol Pi enc-elg from Appendix A.2, Figure 24 of CGGMP21.
+
+The statement is `(G, g, N0, C, A, (B, X))`. The witness is `(x, rho, a, b)` such that:
+
+$$
+x \in \pm 2^\ell,\quad C = (1+N_0)^x\rho^{N_0} \bmod N_0^2,
+$$
+
+and
+
+$$
+A = g^a,\quad (B, X) = (g^b, A^b g^x).
+$$
+
+The implementation exposes `ell` as `l` and the statistical slack as `epsilon`.
+
+## Protocol
+
+The prover samples:
+
+$$
+\alpha \leftarrow \pm 2^{\ell+\epsilon},\quad
+\beta \leftarrow F_q,\quad
+\mu \leftarrow \pm 2^\ell \hat N,
+$$
+
+$$
+r \leftarrow Z^*_{N_0},\quad
+\gamma \leftarrow \pm 2^{\ell+\epsilon}\hat N.
+$$
+
+It sends:
+
+$$
+S = s^x t^\mu,\quad T = s^\alpha t^\gamma,
+$$
+
+$$
+D = (1+N_0)^\alpha r^{N_0} \bmod N_0^2,
+$$
+
+$$
+(Z, Y) = (g^\beta, A^\beta g^\alpha).
+$$
+
+The verifier replies with a signed 16-byte challenge `e`. The response is:
+
+$$
+z_1 = \alpha + ex,\quad z_2 = r\rho^e \bmod N_0,
+$$
+
+$$
+z_3 = \gamma + e\mu,\quad w = \beta + eb \bmod q.
+$$
+
+The verifier checks:
+
+$$
+(1+N_0)^{z_1}z_2^{N_0} = DC^e \bmod N_0^2,
+$$
+
+$$
+\operatorname{Enc}_A(g^{z_1}; w) = (Z, Y)(B, X)^e,
+$$
+
+$$
+s^{z_1}t^{z_3} = TS^e \bmod \hat N,
+$$
+
+and the widened range:
+
+$$
+z_1 \in \pm 2^{\ell+\epsilon}.
+$$
+
+## Implementation Notes
+
+- `Statement` stores `N0`, `C`, `A` as an ElGamal public key, and `(B, X)` as an ElGamal ciphertext named `bx`.
+- `Witness` stores `x` as `*num.Int`, `rho` as a Paillier nonce, `a` as an ElGamal secret key, and the `(B, X)` nonce as `bx`.
+- `Commitment` stores `(Z, Y)` as an ElGamal ciphertext named `yz` under `A`.
+- The challenge is interpreted as a signed integer from exactly `base.ComputationalSecurityBytesCeil` bytes.
+- Signed integer samples use byte-aligned two's-complement sampling over exactly the requested byte length.
+- `ValidateStatement` checks that the witness opens `C`, `A`, and the ElGamal ciphertext `(B, X)`, and that `x` satisfies the configured narrow range.
+- Statement validation checks that the Paillier modulus can encode the widened `z1` range `l + epsilon` in its symmetric plaintext interval.
+
+## Reference
+
+<!-- paper: docs/papers/2021-060_20241021_172019.pdf [Appendix A.2, Figure 24] -->
+- Canetti, Gennaro, Goldfeder, Makriyannis, Peled.
+  [UC Non-Interactive, Proactive, Threshold ECDSA with Identifiable Aborts](https://eprint.iacr.org/2021/060),
+  Appendix A.2, Figure 24.

--- a/pkg/proofs/cggmp21/encelg/doc.go
+++ b/pkg/proofs/cggmp21/encelg/doc.go
@@ -1,0 +1,3 @@
+// Package encelg implements CGGMP21 Figure 24, the Paillier range proof with
+// ElGamal-style group commitment.
+package encelg

--- a/pkg/proofs/cggmp21/encelg/doc.go
+++ b/pkg/proofs/cggmp21/encelg/doc.go
@@ -1,3 +1,7 @@
 // Package encelg implements CGGMP21 Figure 24, the Paillier range proof with
 // ElGamal-style group commitment.
+//
+// CBOR unmarshalling validates local structure and nested type constructors.
+// Contextual checks that depend on protocol parameters or statement/witness
+// relations are performed by Protocol.ValidateStatement and Protocol.Verify.
 package encelg

--- a/pkg/proofs/cggmp21/encelg/encelg.go
+++ b/pkg/proofs/cggmp21/encelg/encelg.go
@@ -1,0 +1,296 @@
+package encelg
+
+import (
+	"encoding/binary"
+
+	"github.com/bronlabs/errs-go/errs"
+
+	"github.com/bronlabs/bron-crypto/pkg/base/algebra"
+	"github.com/bronlabs/bron-crypto/pkg/base/curves"
+	"github.com/bronlabs/bron-crypto/pkg/base/nt/num"
+	"github.com/bronlabs/bron-crypto/pkg/base/serde"
+	"github.com/bronlabs/bron-crypto/pkg/base/utils"
+	"github.com/bronlabs/bron-crypto/pkg/base/utils/sliceutils"
+	"github.com/bronlabs/bron-crypto/pkg/commitments/intcom"
+	"github.com/bronlabs/bron-crypto/pkg/encryption/elgamal"
+	"github.com/bronlabs/bron-crypto/pkg/encryption/paillier"
+	"github.com/bronlabs/bron-crypto/pkg/proofs/sigma"
+)
+
+const (
+	// Name identifies the CGGMP21 range proof with ElGamal-style group commitment.
+	Name sigma.Name = "CGGMP21_RANGE_PROOF_WITH_ELGAMAL_COMMITMENT"
+)
+
+// Statement is the public input (N0, C, A, (B, X)) for CGGMP21 Figure 24.
+type Statement[G curves.Point[G, B, S], B algebra.PrimeFieldElement[B], S algebra.PrimeFieldElement[S]] struct {
+	n0 *paillier.PublicKey
+	c  *paillier.Ciphertext
+	a  *elgamal.PublicKey[G, S]
+	bx *elgamal.Ciphertext[G, S]
+}
+
+type statementDTO[G curves.Point[G, B, S], B algebra.PrimeFieldElement[B], S algebra.PrimeFieldElement[S]] struct {
+	N0 *paillier.PublicKey       `cbor:"n0"`
+	C  *paillier.Ciphertext      `cbor:"c"`
+	A  *elgamal.PublicKey[G, S]  `cbor:"a"`
+	BX *elgamal.Ciphertext[G, S] `cbor:"bx"`
+}
+
+// NewStatement constructs an enc-elg statement.
+func NewStatement[G curves.Point[G, B, S], B algebra.PrimeFieldElement[B], S algebra.PrimeFieldElement[S]](
+	n0 *paillier.PublicKey,
+	c *paillier.Ciphertext,
+	a *elgamal.PublicKey[G, S],
+	bx *elgamal.Ciphertext[G, S],
+) (*Statement[G, B, S], error) {
+	if n0 == nil || c == nil || a == nil || bx == nil {
+		return nil, ErrInvalidArgument.WithMessage("statement values must not be nil")
+	}
+	return &Statement[G, B, S]{
+		n0: n0,
+		c:  c,
+		a:  a,
+		bx: bx,
+	}, nil
+}
+
+// MarshalCBOR serialises the statement to CBOR format.
+func (s *Statement[G, B, S]) MarshalCBOR() ([]byte, error) {
+	dto := &statementDTO[G, B, S]{
+		N0: s.n0,
+		C:  s.c,
+		A:  s.a,
+		BX: s.bx,
+	}
+	out, err := serde.MarshalCBOR(dto)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not marshal statement to CBOR")
+	}
+	return out, nil
+}
+
+// UnmarshalCBOR deserialises the statement from CBOR format.
+func (s *Statement[G, B, S]) UnmarshalCBOR(data []byte) error {
+	dto, err := serde.UnmarshalCBOR[*statementDTO[G, B, S]](data)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not unmarshal statement from CBOR")
+	}
+	if dto == nil {
+		return ErrInvalidArgument.WithMessage("statement DTO must not be nil")
+	}
+	statement, err := NewStatement(dto.N0, dto.C, dto.A, dto.BX)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("invalid statement data")
+	}
+	*s = *statement
+	return nil
+}
+
+// Bytes serialises the statement for transcript binding.
+func (s *Statement[G, B, S]) Bytes() []byte {
+	out := binary.LittleEndian.AppendUint64(nil, 4)
+	out = sliceutils.AppendLengthPrefixed(out, s.n0.Group().N().Bytes())
+	out = sliceutils.AppendLengthPrefixed(out, s.c.Bytes())
+	out = sliceutils.AppendLengthPrefixed(out, s.a.Value().Bytes())
+	for _, component := range s.bx.Value().Components() {
+		out = sliceutils.AppendLengthPrefixed(out, component.Bytes())
+	}
+	return out
+}
+
+// Witness is the secret input (x, rho, a, bx) for CGGMP21 Figure 24.
+type Witness[G elgamal.FiniteCyclicGroupElement[G, S], S algebra.PrimeFieldElement[S]] struct {
+	x   *num.Int
+	rho *paillier.Nonce
+	a   *elgamal.SecretKey[G, S]
+	bx  *elgamal.Nonce[S]
+}
+
+// NewWitness constructs an enc-elg witness.
+func NewWitness[G elgamal.FiniteCyclicGroupElement[G, S], S algebra.PrimeFieldElement[S]](
+	x *num.Int,
+	rho *paillier.Nonce,
+	a *elgamal.SecretKey[G, S],
+	bx *elgamal.Nonce[S],
+) (*Witness[G, S], error) {
+	if x == nil || rho == nil || a == nil || bx == nil {
+		return nil, ErrInvalidArgument.WithMessage("witness values must not be nil")
+	}
+	return &Witness[G, S]{
+		x:   x.Clone(),
+		rho: rho,
+		a:   a,
+		bx:  bx,
+	}, nil
+}
+
+// State stores the prover's sampled randomness between sigma rounds.
+type State[S algebra.PrimeFieldElement[S]] struct {
+	alpha *num.Int
+	beta  S
+	mu    *num.Int
+	r     *paillier.Nonce
+	gamma *num.Int
+}
+
+// NewState constructs the prover state retained between sigma rounds.
+func NewState[S algebra.PrimeFieldElement[S]](alpha *num.Int, beta S, mu *num.Int, r *paillier.Nonce, gamma *num.Int) (*State[S], error) {
+	if alpha == nil || mu == nil || r == nil || gamma == nil || utils.IsNil(beta) {
+		return nil, ErrInvalidArgument.WithMessage("state values must not be nil")
+	}
+	return &State[S]{
+		alpha: alpha,
+		beta:  beta,
+		mu:    mu,
+		r:     r,
+		gamma: gamma,
+	}, nil
+}
+
+// Commitment is the prover's first message (S, T, D, (Z, Y)).
+type Commitment[G curves.Point[G, B, S], B algebra.PrimeFieldElement[B], S algebra.PrimeFieldElement[S]] struct {
+	s  *intcom.Commitment
+	t  *intcom.Commitment
+	d  *paillier.Ciphertext
+	yz *elgamal.Ciphertext[G, S]
+}
+
+type commitmentDTO[G curves.Point[G, B, S], B algebra.PrimeFieldElement[B], S algebra.PrimeFieldElement[S]] struct {
+	S  *intcom.Commitment        `cbor:"s"`
+	T  *intcom.Commitment        `cbor:"t"`
+	D  *paillier.Ciphertext      `cbor:"d"`
+	YZ *elgamal.Ciphertext[G, S] `cbor:"yz"`
+}
+
+// NewCommitment constructs an enc-elg commitment.
+func NewCommitment[G curves.Point[G, B, S], B algebra.PrimeFieldElement[B], S algebra.PrimeFieldElement[S]](
+	s *intcom.Commitment,
+	t *intcom.Commitment,
+	d *paillier.Ciphertext,
+	yz *elgamal.Ciphertext[G, S],
+) (*Commitment[G, B, S], error) {
+	if s == nil || t == nil || d == nil || yz == nil {
+		return nil, ErrInvalidArgument.WithMessage("commitment values must not be nil")
+	}
+	return &Commitment[G, B, S]{
+		s:  s,
+		t:  t,
+		d:  d,
+		yz: yz,
+	}, nil
+}
+
+// MarshalCBOR serialises the commitment to CBOR format.
+func (c *Commitment[G, B, S]) MarshalCBOR() ([]byte, error) {
+	dto := &commitmentDTO[G, B, S]{
+		S:  c.s,
+		T:  c.t,
+		D:  c.d,
+		YZ: c.yz,
+	}
+	out, err := serde.MarshalCBOR(dto)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not marshal commitment to CBOR")
+	}
+	return out, nil
+}
+
+// UnmarshalCBOR deserialises the commitment from CBOR format.
+func (c *Commitment[G, B, S]) UnmarshalCBOR(data []byte) error {
+	dto, err := serde.UnmarshalCBOR[*commitmentDTO[G, B, S]](data)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not unmarshal commitment from CBOR")
+	}
+	if dto == nil {
+		return ErrInvalidArgument.WithMessage("commitment DTO must not be nil")
+	}
+	commitment, err := NewCommitment(dto.S, dto.T, dto.D, dto.YZ)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("invalid commitment data")
+	}
+	*c = *commitment
+	return nil
+}
+
+// Bytes serialises the commitment for transcript binding.
+func (c *Commitment[G, B, S]) Bytes() []byte {
+	out := binary.LittleEndian.AppendUint64(nil, 4)
+	out = sliceutils.AppendLengthPrefixed(out, c.s.Value().Bytes())
+	out = sliceutils.AppendLengthPrefixed(out, c.t.Value().Bytes())
+	out = sliceutils.AppendLengthPrefixed(out, c.d.Bytes())
+	for _, component := range c.yz.Value().Components() {
+		out = sliceutils.AppendLengthPrefixed(out, component.Bytes())
+	}
+	return out
+}
+
+// Response is the prover's final message (z1, z2, z3, w).
+type Response[S algebra.PrimeFieldElement[S]] struct {
+	z1 *num.Int
+	z2 *paillier.Nonce
+	z3 *num.Int
+	w  S
+}
+
+type responseDTO[S algebra.PrimeFieldElement[S]] struct {
+	Z1 *num.Int        `cbor:"z1"`
+	Z2 *paillier.Nonce `cbor:"z2"`
+	Z3 *num.Int        `cbor:"z3"`
+	W  S               `cbor:"w"`
+}
+
+// NewResponse constructs an enc-elg response.
+func NewResponse[S algebra.PrimeFieldElement[S]](z1 *num.Int, z2 *paillier.Nonce, z3 *num.Int, w S) (*Response[S], error) {
+	if z1 == nil || z2 == nil || z3 == nil || utils.IsNil(w) {
+		return nil, ErrInvalidArgument.WithMessage("response values must not be nil")
+	}
+	return &Response[S]{
+		z1: z1,
+		z2: z2,
+		z3: z3,
+		w:  w,
+	}, nil
+}
+
+// MarshalCBOR serialises the response to CBOR format.
+func (r *Response[S]) MarshalCBOR() ([]byte, error) {
+	dto := &responseDTO[S]{
+		Z1: r.z1,
+		Z2: r.z2,
+		Z3: r.z3,
+		W:  r.w,
+	}
+	out, err := serde.MarshalCBOR(dto)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not marshal response to CBOR")
+	}
+	return out, nil
+}
+
+// UnmarshalCBOR deserialises the response from CBOR format.
+func (r *Response[S]) UnmarshalCBOR(data []byte) error {
+	dto, err := serde.UnmarshalCBOR[*responseDTO[S]](data)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not unmarshal response from CBOR")
+	}
+	if dto == nil {
+		return ErrInvalidArgument.WithMessage("response DTO must not be nil")
+	}
+	response, err := NewResponse(dto.Z1, dto.Z2, dto.Z3, dto.W)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("invalid response data")
+	}
+	*r = *response
+	return nil
+}
+
+// Bytes serialises the response for transcript binding.
+func (r *Response[S]) Bytes() []byte {
+	out := binary.LittleEndian.AppendUint64(nil, 4)
+	out = sliceutils.AppendLengthPrefixed(out, r.z1.Bytes())
+	out = sliceutils.AppendLengthPrefixed(out, r.z2.Bytes())
+	out = sliceutils.AppendLengthPrefixed(out, r.z3.Bytes())
+	out = sliceutils.AppendLengthPrefixed(out, r.w.Bytes())
+	return out
+}

--- a/pkg/proofs/cggmp21/encelg/encelg_smoke_test.go
+++ b/pkg/proofs/cggmp21/encelg/encelg_smoke_test.go
@@ -1,0 +1,19 @@
+package encelg_test
+
+import (
+	"github.com/bronlabs/bron-crypto/pkg/base/algebra"
+	"github.com/bronlabs/bron-crypto/pkg/base/curves"
+	"github.com/bronlabs/bron-crypto/pkg/proofs/cggmp21/encelg"
+	"github.com/bronlabs/bron-crypto/pkg/proofs/sigma"
+	"github.com/bronlabs/bron-crypto/pkg/signatures/ecdsa"
+)
+
+func _[G curves.Point[G, B, S], B algebra.PrimeFieldElement[B], S algebra.PrimeFieldElement[S]](_ ecdsa.Curve[G, B, S]) {
+	var _ sigma.Statement = (*encelg.Statement[G, B, S])(nil)
+	var _ sigma.Witness = (*encelg.Witness[G, S])(nil)
+	var _ sigma.State = (*encelg.State[S])(nil)
+	var _ sigma.Commitment = (*encelg.Commitment[G, B, S])(nil)
+	var _ sigma.Response = (*encelg.Response[S])(nil)
+
+	var _ sigma.Protocol[*encelg.Statement[G, B, S], *encelg.Witness[G, S], *encelg.Commitment[G, B, S], *encelg.State[S], *encelg.Response[S]] = (*encelg.Protocol[G, B, S])(nil)
+}

--- a/pkg/proofs/cggmp21/encelg/errors.go
+++ b/pkg/proofs/cggmp21/encelg/errors.go
@@ -1,0 +1,12 @@
+package encelg
+
+import "github.com/bronlabs/errs-go/errs"
+
+var (
+	// ErrInvalidArgument indicates missing or inconsistent protocol inputs.
+	ErrInvalidArgument = errs.New("invalid argument")
+	// ErrValidationFailed indicates that a statement/witness pair is malformed or inconsistent.
+	ErrValidationFailed = errs.New("validation failed")
+	// ErrVerificationFailed indicates a failed sigma-protocol verification.
+	ErrVerificationFailed = errs.New("verification failed")
+)

--- a/pkg/proofs/cggmp21/encelg/helpers.go
+++ b/pkg/proofs/cggmp21/encelg/helpers.go
@@ -25,7 +25,7 @@ func intSampleRangeSymmetricBits(bitLen int, prngReader io.Reader) (*num.Int, er
 }
 
 func intInSignedBitRange(v *num.Int, bitLen int) bool {
-	return v.Abs().TrueLen() <= bitLen
+	return v.Abs().TrueLen() < bitLen
 }
 
 func intToPlaintext(v *num.Int, paillierKey *paillier.PublicKey) (*paillier.Plaintext, error) {

--- a/pkg/proofs/cggmp21/encelg/helpers.go
+++ b/pkg/proofs/cggmp21/encelg/helpers.go
@@ -1,0 +1,71 @@
+package encelg
+
+import (
+	"io"
+	"math/big"
+
+	"github.com/bronlabs/errs-go/errs"
+
+	"github.com/bronlabs/bron-crypto/pkg/base/algebra"
+	"github.com/bronlabs/bron-crypto/pkg/base/nt/num"
+	"github.com/bronlabs/bron-crypto/pkg/encryption/paillier"
+)
+
+func intSampleRangeSymmetricBits(bitLen int, prngReader io.Reader) (*num.Int, error) {
+	buf := make([]byte, bitLen/8)
+	if _, err := io.ReadFull(prngReader, buf); err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not sample integer bytes")
+	}
+
+	out, err := num.Z().FromTwosComplementBytesBE(buf)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not parse sampled integer")
+	}
+	return out, nil
+}
+
+func intInSignedBitRange(v *num.Int, bitLen int) bool {
+	return v.Abs().TrueLen() <= bitLen
+}
+
+func intToPlaintext(v *num.Int, paillierKey *paillier.PublicKey) (*paillier.Plaintext, error) {
+	out, err := paillier.NewPlaintextSymmetric(v, paillierKey.PlaintextGroup().Modulus())
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not create signed Paillier plaintext")
+	}
+	return out, nil
+}
+
+func intToScalar[S algebra.PrimeFieldElement[S]](v *num.Int, scalarField algebra.PrimeField[S]) (S, error) {
+	var nilS S
+	if v == nil {
+		return nilS, ErrInvalidArgument.WithMessage("integer must not be nil")
+	}
+	if scalarField == nil {
+		return nilS, ErrInvalidArgument.WithMessage("scalar field must not be nil")
+	}
+
+	modulus := scalarField.Order().Big()
+	reduced := new(big.Int).Mod(v.Big(), modulus)
+	if reduced.Sign() == 0 {
+		return scalarField.FromUint64(0), nil
+	}
+	out, err := scalarField.FromBytesBEReduce(reduced.Bytes())
+	if err != nil {
+		return nilS, errs.Wrap(err).WithMessage("could not reduce integer to scalar")
+	}
+	return out, nil
+}
+
+func signedBoundFitsPaillier(bits int, paillierKey *paillier.PublicKey) error {
+	if paillierKey == nil {
+		return ErrInvalidArgument.WithMessage("Paillier key must not be nil")
+	}
+	modulus := paillierKey.PlaintextGroup().Modulus()
+	bound := num.Z().One().Lsh(uint(bits))
+	halfModulus := modulus.Rsh(1).Lift()
+	if !bound.IsLessThanOrEqual(halfModulus) {
+		return ErrValidationFailed.WithMessage("2^%d must fit in the Paillier symmetric plaintext range", bits)
+	}
+	return nil
+}

--- a/pkg/proofs/cggmp21/encelg/protocol.go
+++ b/pkg/proofs/cggmp21/encelg/protocol.go
@@ -1,0 +1,599 @@
+package encelg
+
+import (
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/bronlabs/errs-go/errs"
+
+	"github.com/bronlabs/bron-crypto/pkg/base"
+	"github.com/bronlabs/bron-crypto/pkg/base/algebra"
+	"github.com/bronlabs/bron-crypto/pkg/base/curves"
+	"github.com/bronlabs/bron-crypto/pkg/base/nt/num"
+	"github.com/bronlabs/bron-crypto/pkg/base/utils"
+	"github.com/bronlabs/bron-crypto/pkg/commitments/intcom"
+	"github.com/bronlabs/bron-crypto/pkg/encryption/elgamal"
+	"github.com/bronlabs/bron-crypto/pkg/encryption/paillier"
+	"github.com/bronlabs/bron-crypto/pkg/proofs/sigma"
+	"github.com/bronlabs/bron-crypto/pkg/signatures/ecdsa"
+)
+
+// Protocol implements the CGGMP21 range proof with ElGamal commitment from Figure 24.
+type Protocol[G curves.Point[G, B, S], B algebra.PrimeFieldElement[B], S algebra.PrimeFieldElement[S]] struct {
+	name            sigma.Name
+	ringPedersenKey *intcom.CommitmentKey
+	l               int
+	epsilon         int
+	curve           ecdsa.Curve[G, B, S]
+	prng            io.Reader
+}
+
+// NewProtocol constructs the CGGMP21 Figure 24 range proof with ElGamal commitment.
+func NewProtocol[G curves.Point[G, B, S], B algebra.PrimeFieldElement[B], S algebra.PrimeFieldElement[S]](ringPedersenKey *intcom.CommitmentKey, l, epsilon int, curve ecdsa.Curve[G, B, S], prng io.Reader) (*Protocol[G, B, S], error) {
+	if ringPedersenKey == nil || ringPedersenKey.Group().Modulus().TrueLen()%8 != 0 {
+		return nil, ErrInvalidArgument.WithMessage("ringPedersenKey is required")
+	}
+	if prng == nil {
+		return nil, ErrInvalidArgument.WithMessage("prng is required")
+	}
+	if utils.IsNil(curve) {
+		return nil, ErrInvalidArgument.WithMessage("curve is required")
+	}
+	if (l <= 0) || (l%8 != 0) {
+		return nil, ErrInvalidArgument.WithMessage("l must be a multiple of 8")
+	}
+	if (epsilon <= 0) || (epsilon%8 != 0) {
+		return nil, ErrInvalidArgument.WithMessage("epsilon must be a multiple of 8")
+	}
+
+	k := curve.ScalarField().BitLen()
+	if k < base.ComputationalSecurityBits {
+		return nil, ErrInvalidArgument.WithMessage("invalid curve")
+	}
+	if l < k {
+		return nil, ErrInvalidArgument.WithMessage("invalid l")
+	}
+	if epsilon < l+k {
+		return nil, ErrInvalidArgument.WithMessage("invalid epsilon")
+	}
+	logN := ringPedersenKey.Group().Modulus().TrueLen()
+	if logN < l+epsilon {
+		return nil, ErrInvalidArgument.WithMessage("invalid ring pedersen key")
+	}
+	if !testing.Testing() && logN < base.IFCKeyLength {
+		return nil, ErrInvalidArgument.WithMessage("invalid ring pedersen key len")
+	}
+
+	name := sigma.Name(fmt.Sprintf(
+		"%s_L=%d_EPS=%d_CURVE=%s_NHAT=%s_S=%x_T=%x",
+		Name,
+		l,
+		epsilon,
+		curve.Name(),
+		ringPedersenKey.Group().Modulus().String(),
+		ringPedersenKey.S().Bytes(),
+		ringPedersenKey.T().Bytes(),
+	))
+	p := &Protocol[G, B, S]{
+		name:            name,
+		ringPedersenKey: ringPedersenKey,
+		l:               l,
+		epsilon:         epsilon,
+		curve:           curve,
+		prng:            prng,
+	}
+	return p, nil
+}
+
+// Name returns the protocol identifier, including public parameters.
+func (p *Protocol[G, B, S]) Name() sigma.Name {
+	return p.name
+}
+
+// ComputeProverCommitment generates the prover's first message.
+func (p *Protocol[G, B, S]) ComputeProverCommitment(statement *Statement[G, B, S], witness *Witness[G, S]) (*Commitment[G, B, S], *State[S], error) {
+	if statement == nil {
+		return nil, nil, ErrInvalidArgument.WithMessage("statement must not be nil")
+	}
+	if witness == nil {
+		return nil, nil, ErrInvalidArgument.WithMessage("witness must not be nil")
+	}
+	if err := p.validateStatement(statement); err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("invalid statement")
+	}
+
+	state, err := p.sampleState(statement)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not sample prover state")
+	}
+	commitment, err := p.computeCommitment(statement, witness, state)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not compute prover commitment")
+	}
+	return commitment, state, nil
+}
+
+// ComputeProverResponse generates the prover response for a fixed challenge.
+func (p *Protocol[G, B, S]) ComputeProverResponse(statement *Statement[G, B, S], witness *Witness[G, S], commitment *Commitment[G, B, S], state *State[S], challenge sigma.ChallengeBytes) (*Response[S], error) {
+	if statement == nil {
+		return nil, ErrInvalidArgument.WithMessage("statement must not be nil")
+	}
+	if witness == nil {
+		return nil, ErrInvalidArgument.WithMessage("witness must not be nil")
+	}
+	if commitment == nil {
+		return nil, ErrInvalidArgument.WithMessage("commitment must not be nil")
+	}
+	if state == nil {
+		return nil, ErrInvalidArgument.WithMessage("state must not be nil")
+	}
+	if err := p.validateStatement(statement); err != nil {
+		return nil, errs.Wrap(err).WithMessage("invalid statement")
+	}
+	e, eScalar, err := p.mapChallenge(challenge)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("invalid challenge")
+	}
+
+	z1 := state.alpha.Add(e.Mul(witness.x))
+	rhoE, err := statement.n0.NonceScalarOp(witness.rho, e)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not compute rho^e")
+	}
+	z2, err := statement.n0.NonceOp(state.r, rhoE)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not compute z2")
+	}
+	z3 := state.gamma.Add(e.Mul(state.mu))
+	w := state.beta.Add(eScalar.Mul(witness.bx.Value()))
+
+	response, err := NewResponse(z1, z2, z3, w)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not create response")
+	}
+	return response, nil
+}
+
+// Verify checks the Figure 24 equality checks and widened response range.
+func (p *Protocol[G, B, S]) Verify(statement *Statement[G, B, S], commitment *Commitment[G, B, S], challenge sigma.ChallengeBytes, response *Response[S]) error {
+	if statement == nil {
+		return ErrInvalidArgument.WithMessage("statement must not be nil")
+	}
+	if commitment == nil {
+		return ErrInvalidArgument.WithMessage("commitment must not be nil")
+	}
+	if response == nil {
+		return ErrInvalidArgument.WithMessage("response must not be nil")
+	}
+	if err := p.validateStatement(statement); err != nil {
+		return errs.Wrap(err).WithMessage("invalid statement")
+	}
+	if err := p.validateCommitment(statement, commitment); err != nil {
+		return errs.Wrap(err).WithMessage("invalid commitment")
+	}
+	if err := p.validateResponse(statement, response); err != nil {
+		return errs.Wrap(err).WithMessage("invalid response")
+	}
+	e, eScalar, err := p.mapChallenge(challenge)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("invalid challenge")
+	}
+
+	if !intInSignedBitRange(response.z1, p.l+p.epsilon) {
+		return ErrVerificationFailed.WithMessage("z1 is out of range")
+	}
+	if err := p.verifyPaillier(statement, commitment, response, e); err != nil {
+		return errs.Wrap(err).WithMessage("Paillier equality failed")
+	}
+	if err := p.verifyElGamal(statement, commitment, response, eScalar); err != nil {
+		return errs.Wrap(err).WithMessage("ElGamal equality failed")
+	}
+	if err := p.verifyPedersen(commitment, response, e); err != nil {
+		return errs.Wrap(err).WithMessage("Pedersen equality failed")
+	}
+	return nil
+}
+
+// RunSimulator creates an honest-verifier simulated transcript for a fixed challenge.
+func (p *Protocol[G, B, S]) RunSimulator(statement *Statement[G, B, S], challenge sigma.ChallengeBytes) (*Commitment[G, B, S], *Response[S], error) {
+	if statement == nil {
+		return nil, nil, ErrInvalidArgument.WithMessage("statement must not be nil")
+	}
+	if err := p.validateStatement(statement); err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("invalid statement")
+	}
+	e, eScalar, err := p.mapChallenge(challenge)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("invalid challenge")
+	}
+
+	z1, err := intSampleRangeSymmetricBits(p.l+p.epsilon, p.prng)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not sample z1")
+	}
+	z2, err := statement.n0.SampleNonce(p.prng)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not sample z2")
+	}
+	z3, err := intSampleRangeSymmetricBits(p.l+p.epsilon+p.ringPedersenKey.Group().Modulus().TrueLen(), p.prng)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not sample z3")
+	}
+	w, err := p.curve.ScalarField().Random(p.prng)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not sample w")
+	}
+	response, err := NewResponse(z1, z2, z3, w)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not create response")
+	}
+
+	lambda, err := intSampleRangeSymmetricBits(p.l+p.ringPedersenKey.Group().Modulus().TrueLen(), p.prng)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not sample S opening")
+	}
+	sCommitment, err := p.commit(num.Z().Zero(), lambda)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not compute simulated S")
+	}
+	d, err := p.simulateD(statement, response, e)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not compute simulated D")
+	}
+	yz, err := p.simulateElGamal(statement, response, eScalar)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not compute simulated ElGamal commitment")
+	}
+	t, err := p.simulateT(sCommitment, response, e)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not compute simulated T")
+	}
+
+	commitment, err := NewCommitment(sCommitment, t, d, yz)
+	if err != nil {
+		return nil, nil, errs.Wrap(err).WithMessage("could not create commitment")
+	}
+	return commitment, response, nil
+}
+
+// SpecialSoundness returns the protocol extraction parameter.
+func (*Protocol[G, B, S]) SpecialSoundness() uint {
+	return 2
+}
+
+// SoundnessError returns the challenge size in bits.
+func (p *Protocol[G, B, S]) SoundnessError() uint {
+	return uint(p.GetChallengeBytesLength() * 8)
+}
+
+// GetChallengeBytesLength returns the challenge size in bytes.
+func (*Protocol[G, B, S]) GetChallengeBytesLength() int {
+	return base.ComputationalSecurityBytesCeil
+}
+
+// ValidateStatement checks that the witness opens the public statement and lies in the configured range.
+func (p *Protocol[G, B, S]) ValidateStatement(statement *Statement[G, B, S], witness *Witness[G, S]) error {
+	if statement == nil {
+		return ErrInvalidArgument.WithMessage("statement must not be nil")
+	}
+	if witness == nil {
+		return ErrInvalidArgument.WithMessage("witness must not be nil")
+	}
+	if err := p.validateStatement(statement); err != nil {
+		return errs.Wrap(err).WithMessage("invalid statement")
+	}
+	if err := p.validateWitness(statement, witness); err != nil {
+		return errs.Wrap(err).WithMessage("invalid witness")
+	}
+	return nil
+}
+
+func (p *Protocol[G, B, S]) sampleState(statement *Statement[G, B, S]) (*State[S], error) {
+	nHatBitLen := p.ringPedersenKey.Group().Modulus().TrueLen()
+
+	alpha, err := intSampleRangeSymmetricBits(p.l+p.epsilon, p.prng)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not sample alpha")
+	}
+	beta, err := p.curve.ScalarField().Random(p.prng)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not sample beta")
+	}
+	mu, err := intSampleRangeSymmetricBits(p.l+nHatBitLen, p.prng)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not sample mu")
+	}
+	r, err := statement.n0.SampleNonce(p.prng)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not sample r")
+	}
+	gamma, err := intSampleRangeSymmetricBits(p.l+p.epsilon+nHatBitLen, p.prng)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not sample gamma")
+	}
+
+	state, err := NewState(alpha, beta, mu, r, gamma)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not create state")
+	}
+	return state, nil
+}
+
+func (p *Protocol[G, B, S]) computeCommitment(statement *Statement[G, B, S], witness *Witness[G, S], state *State[S]) (*Commitment[G, B, S], error) {
+	sCommitment, err := p.commit(witness.x, state.mu)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not compute S")
+	}
+	dPlaintext, err := intToPlaintext(state.alpha, statement.n0)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not create alpha plaintext")
+	}
+	d, err := statement.n0.EncryptWithNonce(dPlaintext, state.r)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not compute D")
+	}
+	yz, err := p.encryptElGamal(statement, state.alpha, state.beta)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not compute YZ")
+	}
+	t, err := p.commit(state.alpha, state.gamma)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not compute T")
+	}
+
+	commitment, err := NewCommitment(sCommitment, t, d, yz)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not create commitment")
+	}
+	return commitment, nil
+}
+
+func (*Protocol[G, B, S]) verifyPaillier(statement *Statement[G, B, S], commitment *Commitment[G, B, S], response *Response[S], e *num.Int) error {
+	z1Plaintext, err := intToPlaintext(response.z1, statement.n0)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not create z1 plaintext")
+	}
+	left, err := statement.n0.EncryptWithNonce(z1Plaintext, response.z2)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not compute Paillier left side")
+	}
+	cE, err := statement.n0.CiphertextScalarOp(statement.c, e)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not compute C^e")
+	}
+	right, err := statement.n0.CiphertextOp(commitment.d, cE)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not compute Paillier right side")
+	}
+	if !left.Equal(right) {
+		return ErrVerificationFailed.WithMessage("Paillier equality check failed")
+	}
+	return nil
+}
+
+func (p *Protocol[G, B, S]) encryptElGamal(statement *Statement[G, B, S], message *num.Int, nonceValue S) (*elgamal.Ciphertext[G, S], error) {
+	messageScalar, err := intToScalar(message, p.curve.ScalarField())
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not convert message to scalar")
+	}
+	plaintext, err := elgamal.NewPlaintext[G, S](p.curve.ScalarBaseMul(messageScalar))
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not create ElGamal plaintext")
+	}
+	nonce, err := elgamal.NewNonce[S](nonceValue)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not create ElGamal nonce")
+	}
+	out, err := statement.a.EncryptWithNonce(plaintext, nonce)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not encrypt ElGamal plaintext")
+	}
+	return out, nil
+}
+
+func (p *Protocol[G, B, S]) verifyElGamal(statement *Statement[G, B, S], commitment *Commitment[G, B, S], response *Response[S], e S) error {
+	left, err := p.encryptElGamal(statement, response.z1, response.w)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not compute ElGamal left side")
+	}
+	bxE, err := statement.a.CiphertextScalarOp(statement.bx, e)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not compute BX^e")
+	}
+	right, err := statement.a.CiphertextOp(commitment.yz, bxE)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not compute ElGamal right side")
+	}
+	if !left.Equal(right) {
+		return ErrVerificationFailed.WithMessage("ElGamal equality check failed")
+	}
+	return nil
+}
+
+func (p *Protocol[G, B, S]) verifyPedersen(commitment *Commitment[G, B, S], response *Response[S], e *num.Int) error {
+	left, err := p.commit(response.z1, response.z3)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not compute Pedersen left side")
+	}
+	sE, err := p.ringPedersenKey.CommitmentScalarOp(commitment.s, e)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not compute S^e")
+	}
+	right, err := p.ringPedersenKey.CommitmentOp(commitment.t, sE)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not compute Pedersen right side")
+	}
+	if !left.Equal(right) {
+		return ErrVerificationFailed.WithMessage("Pedersen equality check failed")
+	}
+	return nil
+}
+
+func (*Protocol[G, B, S]) simulateD(statement *Statement[G, B, S], response *Response[S], e *num.Int) (*paillier.Ciphertext, error) {
+	z1Plaintext, err := intToPlaintext(response.z1, statement.n0)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not create z1 plaintext")
+	}
+	encryptedZ1, err := statement.n0.EncryptWithNonce(z1Plaintext, response.z2)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not encrypt z1")
+	}
+	cNegE, err := statement.n0.CiphertextScalarOp(statement.c, e.Neg())
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not compute C^-e")
+	}
+	out, err := statement.n0.CiphertextOp(encryptedZ1, cNegE)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not compute D")
+	}
+	return out, nil
+}
+
+func (p *Protocol[G, B, S]) simulateElGamal(statement *Statement[G, B, S], response *Response[S], e S) (*elgamal.Ciphertext[G, S], error) {
+	left, err := p.encryptElGamal(statement, response.z1, response.w)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not compute ElGamal left side")
+	}
+	bxE, err := statement.a.CiphertextScalarOp(statement.bx, e)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not compute BX^e")
+	}
+	bxNegE, err := statement.a.CiphertextOpInv(bxE)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not compute BX^-e")
+	}
+	out, err := statement.a.CiphertextOp(left, bxNegE)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not compute simulated ElGamal commitment")
+	}
+	return out, nil
+}
+
+func (p *Protocol[G, B, S]) simulateT(sCommitment *intcom.Commitment, response *Response[S], e *num.Int) (*intcom.Commitment, error) {
+	left, err := p.commit(response.z1, response.z3)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not compute response commitment")
+	}
+	sNegE, err := p.ringPedersenKey.CommitmentScalarOp(sCommitment, e.Neg())
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not compute S^-e")
+	}
+	out, err := p.ringPedersenKey.CommitmentOp(left, sNegE)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not compute T")
+	}
+	return out, nil
+}
+
+func (p *Protocol[G, B, S]) commit(messageValue, witnessValue *num.Int) (*intcom.Commitment, error) {
+	message, err := intcom.NewMessage(messageValue)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not create commitment message")
+	}
+	witness, err := intcom.NewWitness(witnessValue)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not create commitment witness")
+	}
+	commitment, err := p.ringPedersenKey.CommitWithWitness(message, witness)
+	if err != nil {
+		return nil, errs.Wrap(err).WithMessage("could not commit")
+	}
+	return commitment, nil
+}
+
+func (p *Protocol[G, B, S]) mapChallenge(challenge sigma.ChallengeBytes) (*num.Int, S, error) {
+	var nilS S
+	if len(challenge) != p.GetChallengeBytesLength() {
+		return nil, nilS, ErrInvalidArgument.WithMessage("invalid challenge length")
+	}
+	e, err := num.Z().FromTwosComplementBytesBE(challenge)
+	if err != nil {
+		return nil, nilS, errs.Wrap(err).WithMessage("could not parse challenge")
+	}
+	eScalar, err := intToScalar(e, p.curve.ScalarField())
+	if err != nil {
+		return nil, nilS, errs.Wrap(err).WithMessage("could not convert challenge to scalar")
+	}
+	return e, eScalar, nil
+}
+
+func (p *Protocol[G, B, S]) validateStatement(statement *Statement[G, B, S]) error {
+	if statement.n0.PlaintextGroup().Modulus().TrueLen()%8 != 0 {
+		return ErrValidationFailed.WithMessage("Paillier modulus bit length must be byte-aligned")
+	}
+	if err := signedBoundFitsPaillier(p.l+p.epsilon, statement.n0); err != nil {
+		return errs.Wrap(err).WithMessage("invalid N0 modulus for z1 response range")
+	}
+	if !statement.n0.CiphertextGroup().Contains(statement.c.Value()) {
+		return ErrValidationFailed.WithMessage("C must be in the N0 ciphertext group")
+	}
+	if !p.curve.Contains(statement.a.Value()) {
+		return ErrValidationFailed.WithMessage("A must be in the curve group")
+	}
+	if !statement.a.CiphertextGroup().Contains(statement.bx.Value()) {
+		return ErrValidationFailed.WithMessage("BX must be in the ElGamal ciphertext group")
+	}
+	return nil
+}
+
+func (p *Protocol[G, B, S]) validateWitness(statement *Statement[G, B, S], witness *Witness[G, S]) error {
+	if !intInSignedBitRange(witness.x, p.l) {
+		return ErrValidationFailed.WithMessage("x is out of range")
+	}
+	if !statement.n0.NonceGroup().Contains(witness.rho.Value()) {
+		return ErrValidationFailed.WithMessage("rho is not in the N0 nonce group")
+	}
+
+	xPlaintext, err := intToPlaintext(witness.x, statement.n0)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not create x plaintext")
+	}
+	cCheck, err := statement.n0.EncryptWithNonce(xPlaintext, witness.rho)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not recompute C")
+	}
+	if !statement.c.Equal(cCheck) {
+		return ErrValidationFailed.WithMessage("witness does not open C")
+	}
+	if !witness.a.Public().Equal(statement.a) {
+		return ErrValidationFailed.WithMessage("a does not open A")
+	}
+	xScalar, err := intToScalar(witness.x, p.curve.ScalarField())
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not convert x to scalar")
+	}
+	elgamalPlaintext, err := elgamal.NewPlaintext[G, S](p.curve.ScalarBaseMul(xScalar))
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not create ElGamal plaintext")
+	}
+	bxCheck, err := statement.a.EncryptWithNonce(elgamalPlaintext, witness.bx)
+	if err != nil {
+		return errs.Wrap(err).WithMessage("could not recompute BX")
+	}
+	if !statement.bx.Equal(bxCheck) {
+		return ErrValidationFailed.WithMessage("witness does not open BX")
+	}
+	return nil
+}
+
+func (p *Protocol[G, B, S]) validateCommitment(statement *Statement[G, B, S], commitment *Commitment[G, B, S]) error {
+	group := p.ringPedersenKey.CommitmentGroup()
+	if !group.Contains(commitment.s.Value()) || !group.Contains(commitment.t.Value()) {
+		return ErrValidationFailed.WithMessage("Pedersen commitments must be in the commitment group")
+	}
+	if !statement.n0.CiphertextGroup().Contains(commitment.d.Value()) {
+		return ErrValidationFailed.WithMessage("D must be in the N0 ciphertext group")
+	}
+	if !statement.a.CiphertextGroup().Contains(commitment.yz.Value()) {
+		return ErrValidationFailed.WithMessage("YZ must be in the ElGamal ciphertext group")
+	}
+	return nil
+}
+
+func (*Protocol[G, B, S]) validateResponse(statement *Statement[G, B, S], response *Response[S]) error {
+	if !statement.n0.NonceGroup().Contains(response.z2.Value()) {
+		return ErrValidationFailed.WithMessage("z2 must be in the N0 nonce group")
+	}
+	return nil
+}

--- a/pkg/proofs/cggmp21/encelg/protocol_test.go
+++ b/pkg/proofs/cggmp21/encelg/protocol_test.go
@@ -1,0 +1,102 @@
+package encelg_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bronlabs/bron-crypto/pkg/base"
+	"github.com/bronlabs/bron-crypto/pkg/base/curves/k256"
+	"github.com/bronlabs/bron-crypto/pkg/base/nt/num"
+	"github.com/bronlabs/bron-crypto/pkg/base/prng/pcg"
+	"github.com/bronlabs/bron-crypto/pkg/commitments/intcom"
+	"github.com/bronlabs/bron-crypto/pkg/encryption/elgamal"
+	"github.com/bronlabs/bron-crypto/pkg/encryption/paillier"
+	ntu "github.com/bronlabs/bron-crypto/pkg/network/testutils"
+	"github.com/bronlabs/bron-crypto/pkg/proofs/cggmp21/encelg"
+)
+
+const (
+	testL       = 256
+	testEpsilon = 512
+	testKeyBits = 2048
+)
+
+func TestProtocolHappyPathAndSimulator(t *testing.T) {
+	t.Parallel()
+
+	prng := pcg.NewRandomised()
+	protocol, statement, witness := sampleProtocolStatementAndWitness(t, prng)
+	require.Equal(t, base.ComputationalSecurityBytesCeil, protocol.GetChallengeBytesLength())
+
+	challenge := make([]byte, protocol.GetChallengeBytesLength())
+	_, err := io.ReadFull(prng, challenge)
+	require.NoError(t, err)
+
+	require.NoError(t, protocol.ValidateStatement(statement, witness))
+
+	commitment, state, err := protocol.ComputeProverCommitment(statement, witness)
+	require.NoError(t, err)
+	response, err := protocol.ComputeProverResponse(statement, witness, commitment, state, challenge)
+	require.NoError(t, err)
+	require.NoError(t, protocol.Verify(statement, commitment, challenge, response))
+
+	roundTrippedStatement := ntu.CBORRoundTrip(t, statement)
+	require.Equal(t, statement.Bytes(), roundTrippedStatement.Bytes())
+	roundTrippedCommitment := ntu.CBORRoundTrip(t, commitment)
+	require.Equal(t, commitment.Bytes(), roundTrippedCommitment.Bytes())
+	roundTrippedResponse := ntu.CBORRoundTrip(t, response)
+	require.Equal(t, response.Bytes(), roundTrippedResponse.Bytes())
+	require.NoError(t, protocol.Verify(roundTrippedStatement, roundTrippedCommitment, challenge, roundTrippedResponse))
+
+	simulatedCommitment, simulatedResponse, err := protocol.RunSimulator(statement, challenge)
+	require.NoError(t, err)
+	require.NoError(t, protocol.Verify(statement, simulatedCommitment, challenge, simulatedResponse))
+}
+
+func sampleProtocolStatementAndWitness(
+	t *testing.T,
+	prng io.Reader,
+) (*encelg.Protocol[*k256.Point, *k256.BaseFieldElement, *k256.Scalar], *encelg.Statement[*k256.Point, *k256.BaseFieldElement, *k256.Scalar], *encelg.Witness[*k256.Point, *k256.Scalar]) {
+	t.Helper()
+
+	ringPedersenKey, err := intcom.SampleCommitmentKey(testKeyBits, prng)
+	require.NoError(t, err)
+	secretKey, err := paillier.SampleSecretKey(testKeyBits, prng)
+	require.NoError(t, err)
+	n0 := secretKey.Public()
+
+	curve := k256.NewCurve()
+	protocol, err := encelg.NewProtocol(ringPedersenKey, testL, testEpsilon, curve, prng)
+	require.NoError(t, err)
+
+	xInt := num.Z().FromInt64(42)
+	xScalar, err := curve.ScalarField().FromBytesBEReduce(xInt.Big().Bytes())
+	require.NoError(t, err)
+	bxScalar, err := curve.ScalarField().Random(prng)
+	require.NoError(t, err)
+
+	aSecretKey, err := elgamal.SampleSecretKey[*k256.Point, *k256.Scalar](curve, prng)
+	require.NoError(t, err)
+	aPublicKey := aSecretKey.Public()
+	bxNonce, err := elgamal.NewNonce[*k256.Scalar](bxScalar)
+	require.NoError(t, err)
+	bxPlaintext, err := elgamal.NewPlaintext[*k256.Point, *k256.Scalar](curve.ScalarBaseMul(xScalar))
+	require.NoError(t, err)
+	bxCiphertext, err := aPublicKey.EncryptWithNonce(bxPlaintext, bxNonce)
+	require.NoError(t, err)
+
+	xPlaintext, err := paillier.NewPlaintextSymmetric(xInt, n0.PlaintextGroup().Modulus())
+	require.NoError(t, err)
+	rho, err := n0.SampleNonce(prng)
+	require.NoError(t, err)
+	c, err := n0.EncryptWithNonce(xPlaintext, rho)
+	require.NoError(t, err)
+
+	statement, err := encelg.NewStatement(n0, c, aPublicKey, bxCiphertext)
+	require.NoError(t, err)
+	witness, err := encelg.NewWitness(xInt, rho, aSecretKey, bxNonce)
+	require.NoError(t, err)
+	return protocol, statement, witness
+}

--- a/pkg/proofs/cggmp21/fac/README.md
+++ b/pkg/proofs/cggmp21/fac/README.md
@@ -70,7 +70,8 @@ $Q^{z_1}t^v=TR^e$. It also verifies the Figure 26 range checks for $z_1,z_2$.
 - `paillier.SecretKey` carries equal-bit-length Paillier factors. After checking $N_0=pq$,
   this balanced factor shape satisfies Figure 26's $p,q \in \pm\sqrt{N_0}\cdot 2^\ell$ witness bound.
 - The Fiat-Shamir challenge bytes are interpreted directly as two's-complement big-endian;
-  for byte-aligned $\ell$, the challenge length is exactly $\ell/8$ bytes.
+  for byte-aligned $\ell$, the challenge length is exactly $\ell/8$ bytes. `NewProtocol`
+  requires $\ell \geq$ `base.ComputationalSecurityBits`.
 
 ## Reference
 

--- a/pkg/proofs/cggmp21/fac/doc.go
+++ b/pkg/proofs/cggmp21/fac/doc.go
@@ -1,2 +1,10 @@
 // Package fac implements the CGGMP21 small-factor sigma protocol.
+//
+// CBOR unmarshalling validates local structure and nested type constructors.
+// Contextual checks that depend on protocol parameters or statement/witness
+// relations are performed by Protocol.ValidateStatement and Protocol.Verify.
+//
+// RunSimulator samples v symmetrically. Figure 26's HVZK text omits the
+// leading signed range marker for v, but the honest value v = r - e*nu*p is
+// signed, so the symmetric simulator distribution is intentional.
 package fac


### PR DESCRIPTION
## Description
Implement CGGMP21 sigma protocols:
  - affg — Figure 25, affine operation with group commitment
  - affgstar — Figure 27, setup-less affine operation with group commitment
  - dec — Figure 28, Paillier special decryption in the exponent
  - encelg — Figure 24, range proof with ElGamal commitment

## Pull Request Checklist

### Scope
- [x] Summary and description are provided.
- [x] Changes are focused and scoped to one purpose.

### Testing (select all that apply)
- [x] Unit tests
- [ ] Property tests
- [ ] Test vectors tests
- [ ] Benchmarks
- [ ] Not run (explain why)

### Documentation / Spec (if relevant)
- [x] Updated/added docs or comments
- [x] Spec updated or linked

### Notes
- [ ] Additional context is provided (if needed)
