### PR TITLE
Make rounter concurrent safe

### DIFF
--- a/pkg/network/README.md
+++ b/pkg/network/README.md
@@ -12,8 +12,8 @@ Utilities for coordinating multi-party protocols: session identifiers, message r
 
 ## Key Types
 
-- `Delivery`: user-supplied transport with context-aware `Send`/`Receive`, `PartyID`, and `Quorum`.
-- `Router`: correlation-aware shim over a `Delivery`; buffers unrelated messages for later retrieval.
+- `Delivery`: user-supplied transport with context-aware `Send`/`Receive`, `PartyID`, and `Quorum`. `Send` must be safe for concurrent use; `Receive` is only called from the router's single reader goroutine.
+- `Router`: correlation-aware shim over a `Delivery`; a single reader demultiplexes incoming messages into per-correlation-ID mailboxes, so concurrent exchanges on distinct correlation IDs are safe. `Namespaced` views let parallel runs of one protocol share a delivery; call `Close` when done with the router.
 - `Runner`: interface for protocol executors (`Run(ctx context.Context, rt *Router, notificationCallback NotificationCallback)`).
 - `SID`: 32-byte session identifier derived via SHA3-256 over user-provided blobs.
 
@@ -22,7 +22,8 @@ Utilities for coordinating multi-party protocols: session identifiers, message r
 1. Implement `Delivery` (or use `testutils.MockCoordinator`) for your environment.
 2. Create a `Router` with `NewRouter(delivery)`.
 3. Exchange messages with `SendTo`/`ReceiveFrom` or use helpers like `SendUnicast`/`ReceiveUnicast`, passing the caller's context.
-4. Compose more complex protocols via runners that accept a `*Router`.
+4. Compose more complex protocols via runners that accept a `*Router`; run concurrent protocol instances over one delivery via `Namespaced` views.
+5. `Close` the router once the session is over.
 
 ## Notes
 

--- a/pkg/network/errors.go
+++ b/pkg/network/errors.go
@@ -3,8 +3,14 @@ package network
 import "github.com/bronlabs/errs-go/errs"
 
 var (
-	ErrInvalidArgument   = errs.New("invalid argument")
-	ErrFailed            = errs.New("failed")
+	// ErrInvalidArgument reports a malformed or unsupported argument.
+	ErrInvalidArgument = errs.New("invalid argument")
+	// ErrFailed reports a generic network-layer failure.
+	ErrFailed = errs.New("failed")
+	// ErrReceiveBufferFull reports that the router's undelivered-message buffer reached its capacity.
 	ErrReceiveBufferFull = errs.New("receive buffer full")
-	ErrDuplicateMessage  = errs.New("duplicate message")
+	// ErrDuplicateMessage reports conflicting messages from one sender under one correlation ID.
+	ErrDuplicateMessage = errs.New("duplicate message")
+	// ErrRouterClosed reports that the router was closed while receiving.
+	ErrRouterClosed = errs.New("router closed")
 )

--- a/pkg/network/router.go
+++ b/pkg/network/router.go
@@ -3,8 +3,7 @@ package network
 import (
 	"bytes"
 	"context"
-	"maps"
-	"slices"
+	"sync"
 
 	"github.com/bronlabs/errs-go/errs"
 
@@ -12,11 +11,15 @@ import (
 	ds "github.com/bronlabs/bron-crypto/pkg/base/datastructures"
 	"github.com/bronlabs/bron-crypto/pkg/base/datastructures/hashset"
 	"github.com/bronlabs/bron-crypto/pkg/base/serde"
-	"github.com/bronlabs/bron-crypto/pkg/base/utils/sliceutils"
 	"github.com/bronlabs/bron-crypto/pkg/mpc/sharing"
 )
 
 // Delivery abstracts a transport layer used by the router.
+//
+// Send must be safe for concurrent use by multiple goroutines. Receive is only
+// ever called sequentially from the router's single reader goroutine;
+// honouring context cancellation in Receive lets Close release that goroutine
+// promptly.
 type Delivery interface {
 	PartyID() sharing.ID
 	Quorum() []sharing.ID
@@ -24,25 +27,60 @@ type Delivery interface {
 	Receive(ctx context.Context) (from sharing.ID, message []byte, err error)
 }
 
-// maxReceiveBufferSize caps the number of out-of-order messages the router
-// will buffer for later retrieval. It bounds memory usage when peers (or a
+// maxReceiveBufferSize caps the number of undelivered messages the router will
+// buffer across all correlation IDs. It bounds memory usage when peers (or a
 // compromised transport) inject messages with unexpected correlation IDs or
 // sender identities.
 const maxReceiveBufferSize = 10000
 
+// namespaceSeparator joins Namespaced prefixes with correlation IDs on the
+// wire. Protocol correlation IDs must not contain it.
+const namespaceSeparator = "/"
+
 // Router orchestrates correlation-aware sending and receiving over a Delivery.
+//
+// A Router is safe for concurrent use: any number of goroutines may call
+// SendTo and ReceiveFrom simultaneously, as long as no two ReceiveFrom calls
+// wait on the same correlation ID at once. A single reader goroutine, started
+// lazily by the first ReceiveFrom, owns Delivery.Receive and demultiplexes
+// incoming messages into per-correlation-ID mailboxes. The reader stops at the
+// first delivery failure, decode failure, or buffer overflow; that failure is
+// latched and returned to every pending and subsequent ReceiveFrom. Call
+// Close once the router is no longer needed, otherwise the reader goroutine
+// lives until the delivery fails.
 type Router struct {
-	receiveBuffer []routerMessage
-	delivery      Delivery
-	quorumSet     ds.Set[sharing.ID]
+	core   *routerCore
+	prefix string
 }
 
 // NewRouter wraps a Delivery with buffering and correlation-aware routing.
 func NewRouter(delivery Delivery) *Router {
 	return &Router{
-		receiveBuffer: nil,
-		delivery:      delivery,
-		quorumSet:     hashset.NewComparable(delivery.Quorum()...).Freeze(),
+		core: &routerCore{
+			delivery:  delivery,
+			quorumSet: hashset.NewComparable(delivery.Quorum()...).Freeze(),
+			mu:        sync.Mutex{},
+			boxes:     make(map[string]*mailbox),
+			buffered:  0,
+			started:   false,
+			stop:      nil,
+			fatal:     nil,
+			failed:    make(chan struct{}),
+		},
+		prefix: "",
+	}
+}
+
+// Namespaced returns a view of the router that prefixes every correlation ID
+// with the given namespace, letting concurrent protocol runs that reuse the
+// same static correlation IDs share one delivery. All views share the reader,
+// buffers, and lifecycle of the parent router, and Close on any view stops
+// them all. All parties of a protocol run must use the same namespace.
+// Namespaces and protocol correlation IDs must not contain "/".
+func (r *Router) Namespaced(namespace string) *Router {
+	return &Router{
+		core:   r.core,
+		prefix: r.prefix + namespace + namespaceSeparator,
 	}
 }
 
@@ -51,14 +89,14 @@ func (r *Router) SendTo(ctx context.Context, correlationID string, messages map[
 	for id, payload := range messages {
 		//nolint:exhaustruct // From is optional
 		message := routerMessage{
-			CorrelationID: correlationID,
+			CorrelationID: r.prefix + correlationID,
 			Payload:       payload,
 		}
 		serializedMessage, err := serde.MarshalCBOR(&message)
 		if err != nil {
 			return errs.Wrap(err).WithMessage("failed to marshal message")
 		}
-		if err := r.delivery.Send(ctx, id, serializedMessage); err != nil {
+		if err := r.core.delivery.Send(ctx, id, serializedMessage); err != nil {
 			return errs.Wrap(err).WithMessage("failed to send message")
 		}
 	}
@@ -66,83 +104,241 @@ func (r *Router) SendTo(ctx context.Context, correlationID string, messages map[
 	return nil
 }
 
-// ReceiveFrom collects messages matching the correlation identifier from the specified senders,
-// buffering unrelated messages for later retrieval.
+// ReceiveFrom collects messages matching the correlation identifier from the
+// specified senders, buffering unrelated messages for later retrieval. It
+// blocks until every requested sender has delivered a message, the context is
+// cancelled, or the router fails. Messages already buffered for the
+// correlation ID survive a cancelled call, so a retry with the same arguments
+// resumes where it left off.
 func (r *Router) ReceiveFrom(ctx context.Context, correlationID string, froms ...sharing.ID) (map[sharing.ID][]byte, error) {
-	received := make(map[sharing.ID][]byte)
-	expected := map[sharing.ID]struct{}{}
-	for _, from := range froms {
-		expected[from] = struct{}{}
-	}
-	var kept []routerMessage
-	for _, bufferedMsg := range r.receiveBuffer {
-		if bufferedMsg.CorrelationID == correlationID {
-			if _, ok := expected[bufferedMsg.From]; !ok {
-				kept = append(kept, bufferedMsg)
-				continue
-			}
-			// If parties send two different messages with the same correlation ID, that's a byzantine behaviour.
-			alreadyReceived, exists := received[bufferedMsg.From]
-			if exists && !bytes.Equal(alreadyReceived, bufferedMsg.Payload) {
-				return nil, ErrDuplicateMessage.WithTag(base.IdentifiableAbortPartyIDTag, bufferedMsg.From).WithMessage("conflicting messages received from sender %d", bufferedMsg.From)
-			}
-			received[bufferedMsg.From] = bufferedMsg.Payload
-		} else {
-			kept = append(kept, bufferedMsg)
-		}
-	}
-	r.receiveBuffer = kept
-
-	for !sliceutils.IsSuperSet(slices.Collect(maps.Keys(received)), froms) {
-		from, serializedMessage, err := r.delivery.Receive(ctx)
-		if err != nil {
-			return nil, errs.Wrap(err).WithMessage("failed to receive message")
-		}
-		// Drop messages from senders outside the session quorum. A compromised
-		// transport layer could otherwise spoof messages from arbitrary IDs.
-		if !r.quorumSet.Contains(from) {
-			continue
-		}
-		message, err := serde.UnmarshalCBOR[routerMessage](serializedMessage)
-		if err != nil {
-			return nil, errs.Wrap(err).WithMessage("failed to decode message")
-		}
-
-		if message.CorrelationID == correlationID {
-			if _, ok := expected[from]; !ok {
-				if len(r.receiveBuffer) >= maxReceiveBufferSize {
-					return nil, ErrReceiveBufferFull.WithMessage("receive buffer exceeded %d messages", maxReceiveBufferSize)
-				}
-				message.From = from
-				r.receiveBuffer = append(r.receiveBuffer, message)
-				continue
-			}
-
-			// If parties send two different messages with the same correlation ID, that's a byzantine behaviour.
-			alreadyReceived, exists := received[from]
-			if exists && !bytes.Equal(alreadyReceived, message.Payload) {
-				return nil, ErrDuplicateMessage.WithTag(base.IdentifiableAbortPartyIDTag, from).WithMessage("conflicting messages received from sender %d", from)
-			}
-			received[from] = message.Payload
-		} else {
-			if len(r.receiveBuffer) >= maxReceiveBufferSize {
-				return nil, ErrReceiveBufferFull.WithMessage("receive buffer exceeded %d messages", maxReceiveBufferSize)
-			}
-			message.From = from
-			r.receiveBuffer = append(r.receiveBuffer, message)
-		}
-	}
-	return received, nil
+	return r.core.receiveFrom(ctx, r.prefix+correlationID, froms)
 }
 
 // PartyID returns the router's local party identifier.
 func (r *Router) PartyID() sharing.ID {
-	return r.delivery.PartyID()
+	return r.core.delivery.PartyID()
 }
 
 // Quorum returns the identifiers of all parties in the session.
 func (r *Router) Quorum() []sharing.ID {
-	return r.delivery.Quorum()
+	return r.core.delivery.Quorum()
+}
+
+// Close stops the reader goroutine and fails all pending and future
+// ReceiveFrom calls with ErrRouterClosed. It does not close the underlying
+// delivery and does not affect SendTo. Close is idempotent and safe for
+// concurrent use.
+func (r *Router) Close() {
+	r.core.shutdown()
+}
+
+// routerCore is the state shared by all namespaced views of one router.
+type routerCore struct {
+	delivery  Delivery
+	quorumSet ds.Set[sharing.ID]
+
+	mu       sync.Mutex
+	boxes    map[string]*mailbox
+	buffered int
+	started  bool
+	stop     context.CancelFunc
+	fatal    error
+	failed   chan struct{}
+}
+
+// mailbox accumulates the messages of one correlation ID, keyed by sender.
+// Payloads stay in the mailbox until a ReceiveFrom call has collected its full
+// expected set, so the reader can detect conflicting duplicates and cancelled
+// calls lose nothing.
+type mailbox struct {
+	payloads map[sharing.ID][]byte
+	poison   error
+	notify   chan struct{}
+}
+
+// signal wakes the attached waiter, if any, without blocking the reader. The
+// waiter re-scans the mailbox under the lock after every wake-up, so a single
+// buffered token cannot miss state changes.
+func (b *mailbox) signal() {
+	if b.notify == nil {
+		return
+	}
+	select {
+	case b.notify <- struct{}{}:
+	default:
+	}
+}
+
+func (c *routerCore) receiveFrom(ctx context.Context, correlationID string, froms []sharing.ID) (map[sharing.ID][]byte, error) {
+	expected := hashset.NewComparable(froms...)
+
+	c.mu.Lock()
+	if c.fatal != nil {
+		fatal := c.fatal
+		c.mu.Unlock()
+		return nil, errs.Wrap(fatal).WithMessage("failed to receive message")
+	}
+	if !c.started {
+		c.started = true
+		readerCtx, cancel := context.WithCancel(context.Background())
+		c.stop = cancel
+		go c.readLoop(readerCtx)
+	}
+	box := c.boxFor(correlationID)
+	if box.notify != nil {
+		c.mu.Unlock()
+		return nil, ErrInvalidArgument.WithMessage("concurrent ReceiveFrom calls share correlation ID %q", correlationID)
+	}
+	notify := make(chan struct{}, 1)
+	box.notify = notify
+	c.mu.Unlock()
+
+	defer func() {
+		c.mu.Lock()
+		box.notify = nil
+		if len(box.payloads) == 0 && box.poison == nil {
+			delete(c.boxes, correlationID)
+		}
+		c.mu.Unlock()
+	}()
+
+	// All outcomes are decided in the locked scan with a fixed priority —
+	// poison, then a complete set, then a latched failure, then cancellation —
+	// so a set completed before a failure or cancellation is still delivered
+	// no matter which wake-up fires first.
+	for {
+		c.mu.Lock()
+		if box.poison != nil {
+			poison := box.poison
+			c.mu.Unlock()
+			return nil, poison
+		}
+		received := make(map[sharing.ID][]byte, expected.Size())
+		complete := true
+		for from := range expected.Iter() {
+			payload, ok := box.payloads[from]
+			if !ok {
+				complete = false
+				break
+			}
+			received[from] = payload
+		}
+		if complete {
+			for from := range expected.Iter() {
+				delete(box.payloads, from)
+			}
+			c.buffered -= expected.Size()
+			c.mu.Unlock()
+			return received, nil
+		}
+		if c.fatal != nil {
+			fatal := c.fatal
+			c.mu.Unlock()
+			return nil, errs.Wrap(fatal).WithMessage("failed to receive message")
+		}
+		if err := ctx.Err(); err != nil {
+			c.mu.Unlock()
+			return nil, errs.Wrap(err).WithMessage("failed to receive message")
+		}
+		c.mu.Unlock()
+
+		select {
+		case <-notify:
+		case <-ctx.Done():
+		case <-c.failed:
+		}
+	}
+}
+
+func (c *routerCore) readLoop(ctx context.Context) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			c.fail(errs.New("router reader panicked: %v", recovered))
+		}
+	}()
+
+	for {
+		from, serializedMessage, err := c.delivery.Receive(ctx)
+		if err != nil {
+			c.fail(errs.Wrap(err).WithMessage("failed to receive message"))
+			return
+		}
+		// Drop messages from senders outside the session quorum. A compromised
+		// transport layer could otherwise spoof messages from arbitrary IDs.
+		if !c.quorumSet.Contains(from) {
+			continue
+		}
+		message, err := serde.UnmarshalCBOR[routerMessage](serializedMessage)
+		if err != nil {
+			c.fail(errs.Wrap(err).WithMessage("failed to decode message"))
+			return
+		}
+		if !c.deposit(from, message) {
+			return
+		}
+	}
+}
+
+// deposit files an incoming message into its correlation mailbox. It reports
+// false when the router latched a fatal error and the reader must stop.
+func (c *routerCore) deposit(from sharing.ID, message routerMessage) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	box := c.boxFor(message.CorrelationID)
+	if existing, ok := box.payloads[from]; ok {
+		// If parties send two different messages with the same correlation ID, that's a byzantine behaviour.
+		if !bytes.Equal(existing, message.Payload) {
+			box.poison = ErrDuplicateMessage.WithTag(base.IdentifiableAbortPartyIDTag, from).WithMessage("conflicting messages received from sender %d", from)
+			box.signal()
+		}
+		return true
+	}
+	if c.buffered >= maxReceiveBufferSize {
+		c.failLocked(ErrReceiveBufferFull.WithMessage("receive buffer exceeded %d messages", maxReceiveBufferSize))
+		return false
+	}
+	box.payloads[from] = message.Payload
+	c.buffered++
+	box.signal()
+	return true
+}
+
+func (c *routerCore) boxFor(correlationID string) *mailbox {
+	box, ok := c.boxes[correlationID]
+	if !ok {
+		box = &mailbox{
+			payloads: make(map[sharing.ID][]byte),
+			poison:   nil,
+			notify:   nil,
+		}
+		c.boxes[correlationID] = box
+	}
+	return box
+}
+
+func (c *routerCore) fail(err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.failLocked(err)
+}
+
+func (c *routerCore) failLocked(err error) {
+	if c.fatal != nil {
+		return
+	}
+	c.fatal = err
+	close(c.failed)
+}
+
+func (c *routerCore) shutdown() {
+	c.mu.Lock()
+	stop := c.stop
+	c.failLocked(ErrRouterClosed)
+	c.mu.Unlock()
+	if stop != nil {
+		stop()
+	}
 }
 
 type routerMessage struct {

--- a/pkg/network/router_prop_test.go
+++ b/pkg/network/router_prop_test.go
@@ -1,0 +1,72 @@
+package network_test
+
+import (
+	"cmp"
+	"context"
+	"slices"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+	"pgregory.net/rapid"
+
+	"github.com/bronlabs/bron-crypto/pkg/mpc/sharing"
+	"github.com/bronlabs/bron-crypto/pkg/network"
+)
+
+func TestRouterDemuxProperty(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(rt *rapid.T) {
+		numSenders := rapid.IntRange(1, 3).Draw(rt, "numSenders")
+		numCorrelationIDs := rapid.IntRange(1, 6).Draw(rt, "numCorrelationIDs")
+
+		quorum := []sharing.ID{1}
+		for s := range numSenders {
+			quorum = append(quorum, sharing.ID(s+2))
+		}
+
+		type entry struct {
+			correlationID string
+			from          sharing.ID
+			payload       []byte
+			order         int
+		}
+		var entries []entry
+		want := make(map[string]map[sharing.ID][]byte)
+		for c := range numCorrelationIDs {
+			correlationID := "cid-" + strconv.Itoa(c)
+			want[correlationID] = make(map[sharing.ID][]byte)
+			for _, from := range quorum[1:] {
+				payload := rapid.SliceOfN(rapid.Byte(), 1, 16).Draw(rt, "payload")
+				order := rapid.Int().Draw(rt, "order")
+				entries = append(entries, entry{correlationID: correlationID, from: from, payload: payload, order: order})
+				want[correlationID][from] = payload
+			}
+		}
+		slices.SortStableFunc(entries, func(a, b entry) int { return cmp.Compare(a.order, b.order) })
+
+		delivery := newStubDelivery(quorum...)
+		router := network.NewRouter(delivery)
+		defer router.Close()
+
+		var group errgroup.Group
+		results := make([]map[sharing.ID][]byte, numCorrelationIDs)
+		for c := range numCorrelationIDs {
+			group.Go(func() error {
+				received, err := router.ReceiveFrom(context.Background(), "cid-"+strconv.Itoa(c), quorum[1:]...)
+				results[c] = received
+				return err
+			})
+		}
+		for _, e := range entries {
+			delivery.deliver(rt, e.from, e.correlationID, e.payload)
+		}
+
+		require.NoError(rt, group.Wait())
+		for c := range numCorrelationIDs {
+			require.Equal(rt, want["cid-"+strconv.Itoa(c)], results[c])
+		}
+	})
+}

--- a/pkg/network/router_test.go
+++ b/pkg/network/router_test.go
@@ -2,24 +2,58 @@ package network_test
 
 import (
 	"context"
+	"errors"
+	"strconv"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/bronlabs/errs-go/errs"
 
 	"github.com/bronlabs/bron-crypto/pkg/base/serde"
 	"github.com/bronlabs/bron-crypto/pkg/mpc/sharing"
 	"github.com/bronlabs/bron-crypto/pkg/network"
 )
 
-type stubDelivery struct {
-	partyID sharing.ID
-	quorum  []sharing.ID
-	queue   []queuedDelivery
+var errStubTransport = errs.New("stub transport failure")
+
+type wireMessage struct {
+	From          sharing.ID `cbor:"from"`
+	CorrelationID string     `cbor:"correlationID"`
+	Payload       []byte     `cbor:"payload"`
 }
 
-type queuedDelivery struct {
+type incomingMessage struct {
 	from    sharing.ID
 	message []byte
+	err     error
+}
+
+type sentMessage struct {
+	to      sharing.ID
+	message []byte
+}
+
+type stubDelivery struct {
+	partyID  sharing.ID
+	quorum   []sharing.ID
+	incoming chan incomingMessage
+
+	mu   sync.Mutex
+	sent []sentMessage
+}
+
+func newStubDelivery(quorum ...sharing.ID) *stubDelivery {
+	return &stubDelivery{
+		partyID:  1,
+		quorum:   quorum,
+		incoming: make(chan incomingMessage, 16384),
+		mu:       sync.Mutex{},
+		sent:     nil,
+	}
 }
 
 func (d *stubDelivery) PartyID() sharing.ID {
@@ -30,47 +64,293 @@ func (d *stubDelivery) Quorum() []sharing.ID {
 	return d.quorum
 }
 
-func (*stubDelivery) Send(context.Context, sharing.ID, []byte) error {
+func (d *stubDelivery) Send(_ context.Context, to sharing.ID, message []byte) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.sent = append(d.sent, sentMessage{to: to, message: message})
 	return nil
 }
 
-func (d *stubDelivery) Receive(context.Context) (sharing.ID, []byte, error) {
-	msg := d.queue[0]
-	d.queue = d.queue[1:]
-	return msg.from, msg.message, nil
+func (d *stubDelivery) Receive(ctx context.Context) (sharing.ID, []byte, error) {
+	select {
+	case <-ctx.Done():
+		return 0, nil, ctx.Err()
+	case m := <-d.incoming:
+		return m.from, m.message, m.err
+	}
+}
+
+func (d *stubDelivery) deliver(tb require.TestingT, from sharing.ID, correlationID string, payload []byte) {
+	raw, err := serde.MarshalCBOR(&wireMessage{CorrelationID: correlationID, Payload: payload})
+	require.NoError(tb, err)
+	d.incoming <- incomingMessage{from: from, message: raw, err: nil}
+}
+
+func (d *stubDelivery) failReceive(err error) {
+	d.incoming <- incomingMessage{from: 0, message: nil, err: err}
+}
+
+func (d *stubDelivery) sentMessages() []sentMessage {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return append([]sentMessage(nil), d.sent...)
 }
 
 func TestRouterReceiveFromFiltersUnexpectedSenders(t *testing.T) {
 	t.Parallel()
 
-	expected, err := serde.MarshalCBOR(&struct {
-		CorrelationID string `cbor:"correlationID"`
-		Payload       []byte `cbor:"payload"`
-	}{
-		CorrelationID: "cid",
-		Payload:       []byte("expected"),
-	})
-	require.NoError(t, err)
-	unexpected, err := serde.MarshalCBOR(&struct {
-		CorrelationID string `cbor:"correlationID"`
-		Payload       []byte `cbor:"payload"`
-	}{
-		CorrelationID: "cid",
-		Payload:       []byte("unexpected"),
-	})
-	require.NoError(t, err)
-
-	delivery := &stubDelivery{
-		partyID: 1,
-		quorum:  []sharing.ID{1, 2, 3},
-		queue: []queuedDelivery{
-			{from: 3, message: unexpected},
-			{from: 2, message: expected},
-		},
-	}
+	delivery := newStubDelivery(1, 2, 3)
+	delivery.deliver(t, 3, "cid", []byte("unexpected"))
+	delivery.deliver(t, 2, "cid", []byte("expected"))
 
 	router := network.NewRouter(delivery)
+	defer router.Close()
+
 	received, err := router.ReceiveFrom(context.Background(), "cid", 2)
 	require.NoError(t, err)
 	require.Equal(t, map[sharing.ID][]byte{2: []byte("expected")}, received)
+
+	received, err = router.ReceiveFrom(context.Background(), "cid", 3)
+	require.NoError(t, err)
+	require.Equal(t, map[sharing.ID][]byte{3: []byte("unexpected")}, received)
+}
+
+func TestRouterConcurrentDisjointCorrelationIDs(t *testing.T) {
+	t.Parallel()
+
+	delivery := newStubDelivery(1, 2, 3)
+	router := network.NewRouter(delivery)
+	defer router.Close()
+
+	var group errgroup.Group
+	group.Go(func() error {
+		received, err := router.ReceiveFrom(context.Background(), "cid-a", 2)
+		if err != nil {
+			return err
+		}
+		require.Equal(t, map[sharing.ID][]byte{2: []byte("payload-a")}, received)
+		return nil
+	})
+	group.Go(func() error {
+		received, err := router.ReceiveFrom(context.Background(), "cid-b", 3)
+		if err != nil {
+			return err
+		}
+		require.Equal(t, map[sharing.ID][]byte{3: []byte("payload-b")}, received)
+		return nil
+	})
+
+	delivery.deliver(t, 3, "cid-b", []byte("payload-b"))
+	delivery.deliver(t, 2, "cid-a", []byte("payload-a"))
+
+	require.NoError(t, group.Wait())
+}
+
+func TestRouterNamespacedViewsIsolate(t *testing.T) {
+	t.Parallel()
+
+	delivery := newStubDelivery(1, 2)
+	router := network.NewRouter(delivery)
+	defer router.Close()
+
+	viewA := router.Namespaced("a")
+	viewB := router.Namespaced("b")
+
+	delivery.deliver(t, 2, "a/cid", []byte("payload-a"))
+	delivery.deliver(t, 2, "b/cid", []byte("payload-b"))
+
+	received, err := viewA.ReceiveFrom(context.Background(), "cid", 2)
+	require.NoError(t, err)
+	require.Equal(t, map[sharing.ID][]byte{2: []byte("payload-a")}, received)
+
+	received, err = viewB.ReceiveFrom(context.Background(), "cid", 2)
+	require.NoError(t, err)
+	require.Equal(t, map[sharing.ID][]byte{2: []byte("payload-b")}, received)
+}
+
+func TestRouterNamespacedSendPrefixesCorrelationID(t *testing.T) {
+	t.Parallel()
+
+	delivery := newStubDelivery(1, 2)
+	router := network.NewRouter(delivery)
+	defer router.Close()
+
+	nested := router.Namespaced("a").Namespaced("x")
+	err := nested.SendTo(context.Background(), "cid", map[sharing.ID][]byte{2: []byte("payload")})
+	require.NoError(t, err)
+
+	sent := delivery.sentMessages()
+	require.Len(t, sent, 1)
+	require.Equal(t, sharing.ID(2), sent[0].to)
+	decoded, err := serde.UnmarshalCBOR[wireMessage](sent[0].message)
+	require.NoError(t, err)
+	require.Equal(t, "a/x/cid", decoded.CorrelationID)
+	require.Equal(t, []byte("payload"), decoded.Payload)
+}
+
+func TestRouterConflictingDuplicatePoisons(t *testing.T) {
+	t.Parallel()
+
+	delivery := newStubDelivery(1, 2, 3)
+	router := network.NewRouter(delivery)
+	defer router.Close()
+
+	delivery.deliver(t, 2, "cid", []byte("one"))
+	delivery.deliver(t, 2, "cid", []byte("two"))
+	delivery.deliver(t, 3, "cid", []byte("three"))
+
+	_, err := router.ReceiveFrom(context.Background(), "cid", 2, 3)
+	require.ErrorIs(t, err, network.ErrDuplicateMessage)
+}
+
+func TestRouterIdenticalDuplicateTolerated(t *testing.T) {
+	t.Parallel()
+
+	delivery := newStubDelivery(1, 2, 3)
+	router := network.NewRouter(delivery)
+	defer router.Close()
+
+	delivery.deliver(t, 2, "cid", []byte("one"))
+	delivery.deliver(t, 2, "cid", []byte("one"))
+	delivery.deliver(t, 3, "cid", []byte("three"))
+
+	received, err := router.ReceiveFrom(context.Background(), "cid", 2, 3)
+	require.NoError(t, err)
+	require.Equal(t, map[sharing.ID][]byte{2: []byte("one"), 3: []byte("three")}, received)
+}
+
+func TestRouterCancelledReceiveKeepsBufferedMessages(t *testing.T) {
+	t.Parallel()
+
+	delivery := newStubDelivery(1, 2, 3)
+	router := network.NewRouter(delivery)
+	defer router.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := router.ReceiveFrom(ctx, "cid", 2, 3)
+		errCh <- err
+	}()
+
+	delivery.deliver(t, 2, "cid", []byte("kept"))
+	cancel()
+	require.ErrorIs(t, <-errCh, context.Canceled)
+
+	received, err := router.ReceiveFrom(context.Background(), "cid", 2)
+	require.NoError(t, err)
+	require.Equal(t, map[sharing.ID][]byte{2: []byte("kept")}, received)
+}
+
+func TestRouterTransportErrorFailsAllReceives(t *testing.T) {
+	t.Parallel()
+
+	delivery := newStubDelivery(1, 2, 3)
+	router := network.NewRouter(delivery)
+	defer router.Close()
+
+	var group errgroup.Group
+	for _, correlationID := range []string{"cid-a", "cid-b"} {
+		group.Go(func() error {
+			_, err := router.ReceiveFrom(context.Background(), correlationID, 2)
+			if !errors.Is(err, errStubTransport) {
+				return err
+			}
+			return nil
+		})
+	}
+
+	delivery.failReceive(errStubTransport)
+	require.NoError(t, group.Wait())
+
+	_, err := router.ReceiveFrom(context.Background(), "cid-c", 2)
+	require.ErrorIs(t, err, errStubTransport)
+}
+
+func TestRouterCloseFailsPendingAndFutureReceives(t *testing.T) {
+	t.Parallel()
+
+	delivery := newStubDelivery(1, 2)
+	router := network.NewRouter(delivery)
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := router.ReceiveFrom(context.Background(), "cid", 2)
+		errCh <- err
+	}()
+
+	view := router.Namespaced("a")
+	view.Close()
+	require.ErrorIs(t, <-errCh, network.ErrRouterClosed)
+
+	_, err := router.ReceiveFrom(context.Background(), "cid", 2)
+	require.ErrorIs(t, err, network.ErrRouterClosed)
+
+	router.Close()
+}
+
+func TestRouterRejectsConcurrentSameCorrelationID(t *testing.T) {
+	t.Parallel()
+
+	delivery := newStubDelivery(1, 2)
+	router := network.NewRouter(delivery)
+	defer router.Close()
+
+	type receiveResult struct {
+		received map[sharing.ID][]byte
+		err      error
+	}
+	resultCh := make(chan receiveResult, 1)
+	go func() {
+		for {
+			received, err := router.ReceiveFrom(context.Background(), "cid", 2)
+			if errors.Is(err, network.ErrInvalidArgument) {
+				continue
+			}
+			resultCh <- receiveResult{received: received, err: err}
+			return
+		}
+	}()
+
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.Eventually(t, func() bool {
+		_, err := router.ReceiveFrom(cancelledCtx, "cid", 2)
+		return errors.Is(err, network.ErrInvalidArgument)
+	}, 5*time.Second, time.Millisecond)
+
+	delivery.deliver(t, 2, "cid", []byte("payload"))
+	result := <-resultCh
+	require.NoError(t, result.err)
+	require.Equal(t, map[sharing.ID][]byte{2: []byte("payload")}, result.received)
+}
+
+func TestRouterDropsMessagesFromOutsideQuorum(t *testing.T) {
+	t.Parallel()
+
+	delivery := newStubDelivery(1, 2)
+	router := network.NewRouter(delivery)
+	defer router.Close()
+
+	delivery.deliver(t, 9, "cid", []byte("spoofed"))
+	delivery.deliver(t, 2, "cid", []byte("real"))
+
+	received, err := router.ReceiveFrom(context.Background(), "cid", 2)
+	require.NoError(t, err)
+	require.Equal(t, map[sharing.ID][]byte{2: []byte("real")}, received)
+}
+
+func TestRouterBufferCapLatchesFailure(t *testing.T) {
+	t.Parallel()
+
+	delivery := newStubDelivery(1, 2)
+	router := network.NewRouter(delivery)
+	defer router.Close()
+
+	for i := range 10001 {
+		delivery.deliver(t, 2, "junk-"+strconv.Itoa(i), nil)
+	}
+
+	_, err := router.ReceiveFrom(context.Background(), "wanted", 2)
+	require.ErrorIs(t, err, network.ErrReceiveBufferFull)
 }

--- a/pkg/network/testutils/executor.go
+++ b/pkg/network/testutils/executor.go
@@ -27,6 +27,7 @@ func TestExecuteRunners[O any](tb testing.TB, runners map[sharing.ID]network.Run
 	for id, runner := range runners {
 		errGroup.Go(func() error {
 			rt := network.NewRouter(testCoordinator.DeliveryFor(id))
+			defer rt.Close()
 
 			var notifications []network.Notification
 			notificationCallback := func(n network.Notification) {
@@ -63,6 +64,7 @@ func TestExecuteRunnersWithQuorum[O any](tb testing.TB, quorum network.Quorum, r
 	for id, runner := range runners {
 		errGroup.Go(func() error {
 			rt := network.NewRouter(testCoordinator.DeliveryFor(id))
+			defer rt.Close()
 
 			var notifications []network.Notification
 			notificationCallback := func(n network.Notification) {


### PR DESCRIPTION
## Description
Changing router to be able to use it for parallel operations. a single reader demultiplexes incoming messages into per-correlation-ID mailboxes, so concurrent exchanges on distinct correlation IDs are safe. `Namespaced` views let parallel runs of one protocol share a delivery

## Pull Request Checklist

### Scope
- [x] Summary and description are provided.
- [x] Changes are focused and scoped to one purpose.

### Testing (select all that apply)
- [x] Unit tests
- [ ] Property tests
- [ ] Test vectors tests
- [ ] Benchmarks
- [ ] Not run (explain why)

### Documentation / Spec (if relevant)
- [x] Updated/added docs or comments
- [ ] Spec updated or linked

### Notes
- [ ] Additional context is provided (if needed)
